### PR TITLE
[JsonGen] Add @extract keyword

### DIFF
--- a/JsonGenerator/source/documentation_generator.py
+++ b/JsonGenerator/source/documentation_generator.py
@@ -161,6 +161,11 @@ def Create(log, schema, path, indent_size = 4):
                         else:
                             row += italics("Value must be in range [%s..%s]." % (d["range"][0], d["range"][1]))
 
+                    if obj.get("extract"):
+                        if row:
+                            row += "<br>"
+                        row += italics("If only one element is present the array will be omitted.")
+
                     MdRow([prefix, "opaque object" if obj.get("opaque") else "string (base64)" if obj.get("encode") else obj["type"], row])
 
                 if obj["type"] == "object":

--- a/JsonGenerator/source/header_loader.py
+++ b/JsonGenerator/source/header_loader.py
@@ -154,6 +154,9 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, includePaths = []):
 
                         result = ["array", { "items": ConvertParameter(currentMethod.retval), "iterator": StripInterfaceNamespace(cppType.type) } ]
 
+                        if "extract" in var.meta.decorators:
+                            result[1]["extract"] = True
+
                         if var_type.IsPointerToPointer():
                             result[1]["ptr"] = True
 

--- a/JsonGenerator/source/rpc_emitter.py
+++ b/JsonGenerator/source/rpc_emitter.py
@@ -670,6 +670,8 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                                 emit.Indent()
                                 emit.Line("%s %s{};" % (arg.items.cpp_native_type, item_name))
                                 emit.Line("while (%s->Next(%s) == true) { %s.Add() = %s; }" % (arg.TempName(), item_name, cpp_name, item_name))
+                                if arg.schema.get("extract"):
+                                    emit.Line("%s.SetExtractOnSingle(true);" % (cpp_name))
                                 emit.Line("%s->Release();" % arg.TempName())
                                 emit.Unindent()
                                 emit.Line("}")

--- a/ProxyStubGenerator/CppParser.py
+++ b/ProxyStubGenerator/CppParser.py
@@ -367,6 +367,8 @@ class Identifier():
                     skip = 1
                 elif token[1:] == "OPAQUE":
                     self.meta.decorators.append("opaque")
+                elif token[1:] == "EXTRACT":
+                    self.meta.decorators.append("extract")
                 elif token[1:] == "PROPERTY":
                     self.meta.is_property = True
                 elif token[1:] == "BRIEF":
@@ -1661,6 +1663,8 @@ def __Tokenize(contents,log = None):
                     tagtokens.append("@BITMASK")
                 if _find("@opaque", token):
                     tagtokens.append("@OPAQUE")
+                if _find("@extract", token):
+                    tagtokens.append("@EXTRACT")
                 if _find("@sourcelocation", token):
                     tagtokens.append(__ParseParameterValue(token, "@sourcelocation"))
                 if _find("@alt", token):

--- a/ProxyStubGenerator/StubGenerator.py
+++ b/ProxyStubGenerator/StubGenerator.py
@@ -2085,6 +2085,7 @@ if __name__ == "__main__":
         print("   @bitmask               - indicates that enumerator lists should be packed into into a bit mask")
         print("   @index                 - indicates that a parameter in a JSON-RPC property or notification is an index")
         print("   @opaque                - indicates that a string parameter is an opaque JSON object")
+        print("   @extract               - indicates that that if only one element is present in the array it shall be taken out of it")
         print("   @prefix {name}         - prefixes all JSON-RPC methods, properties and notifications names in an interface with a string")
         print("   @text {name}           - sets a different name for a parameter, enumerator, struct or JSON-RPC method, property or notification")
         print("   @alt {name}            - provides an alternative name a JSON-RPC method or property can by called by")


### PR DESCRIPTION
If an output iterator is marked as `@extract` and there is only one element in the list, then the resulting JSON element will omit the array (i.e. with no square brackets around).

Needs https://github.com/rdkcentral/Thunder/pull/1462.