### PR TITLE
[JsonGen] Don't prefix RPC endpoint names with namespace

### DIFF
--- a/JsonGenerator/source/config.py
+++ b/JsonGenerator/source/config.py
@@ -55,6 +55,7 @@ DUMP_JSON = False
 FORCE = False
 GENERATED_JSON = False
 LEGACY_ALT = False
+AUTO_PREFIX = False
 
 class RpcFormat(Enum):
     COMPLIANT = "compliant"
@@ -87,6 +88,7 @@ def Parse(cmdline):
     global KEEP_EMPTY
     global CLASSNAME_FROM_REF
     global LEGACY_ALT
+    global AUTO_PREFIX
 
     argparser = argparse.ArgumentParser(
         description='Generate JSON C++ classes, stub code and API documentation from JSON definition files and C++ header files',
@@ -212,6 +214,12 @@ def Parse(cmdline):
             action="store_true",
             default=False,
             help= "do not emit versioning information for non-auto JSON interfaces (default: emit versioning header)")
+    data_group.add_argument(
+            "--auto-prefix",
+            dest="auto_prefix",
+            action="store_true",
+            default=False,
+            help= "prefix JSON-RPC endpoints with C++ namespace (default: no prefix)")
     data_group.add_argument("--legacy-alt",
             dest="legacy_alt",
             action="store_true",
@@ -303,6 +311,7 @@ def Parse(cmdline):
     INTERFACES_SECTION = not args.no_interfaces_section
     INTERFACE_SOURCE_LOCATION = args.source_location
     INTERFACE_SOURCE_REVISION = args.source_revision
+    AUTO_PREFIX = args.auto_prefix
 
     if args.if_namespaces:
         INTERFACE_NAMESPACES = args.if_namespaces

--- a/JsonGenerator/source/header_loader.py
+++ b/JsonGenerator/source/header_loader.py
@@ -455,8 +455,8 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, includePaths = []):
                 continue
 
             if face.obj.json_prefix:
-                prefix = (face.obj.json_prefix + "::")
-            elif face.obj.parent.full_name != ns:
+                prefix = (face.obj.json_prefix + ("::" if not face.obj.json_prefix.endswith("_") else ""))
+            elif config.AUTO_PREFIX and (face.obj.parent.full_name != ns):
                 prefix = (face.obj.parent.name.lower() + "_")
             else:
                 prefix = ""

--- a/cmake/FindJsonGenerator.cmake.in
+++ b/cmake/FindJsonGenerator.cmake.in
@@ -30,7 +30,7 @@ function(JsonGenerator)
         message(FATAL_ERROR "JsonGenerator path ${JSON_GENERATOR} invalid.")
     endif()
 
-    set(optionsArgs CODE STUBS DOCS LEGACY_ALT NO_INCLUDES NO_STYLE_WARNINGS COPY_CTOR NO_REF_NAMES NO_INTERFACES_SECTION VERBOSE FORCE_GENERATE)
+    set(optionsArgs CODE STUBS DOCS LEGACY_ALT AUTO_PREFIX NO_INCLUDES NO_STYLE_WARNINGS COPY_CTOR NO_REF_NAMES NO_INTERFACES_SECTION VERBOSE FORCE_GENERATE)
     set(oneValueArgs OUTPUT CPP_OUTPUT IFDIR CPPIFDIR INDENT DEF_STRING DEF_INT_SIZE PATH FORMAT)
     set(multiValueArgs INPUT INCLUDE_PATH NAMESPACE)
 
@@ -58,6 +58,10 @@ function(JsonGenerator)
 
     if(Argument_LEGACY_ALT)
         list(APPEND _execute_command  "--legacy-alt")
+    endif()
+
+    if(Argument_AUTO_PREFIX)
+        list(APPEND _execute_command  "--auto-prefix")
     endif()
 
     if(Argument_NO_INCLUDES)


### PR DESCRIPTION
Legacy behavior reachable with --auto-prefix switch.