### PR TITLE
[STARTMODE] Preperations for R5, starmode supersedes the autostart flag.

### DIFF
--- a/ConfigGenerator/params.config
+++ b/ConfigGenerator/params.config
@@ -1,4 +1,4 @@
-autostart
+startmode
 callsign
 communicator
 configuration

--- a/JsonGenerator/source/documentation_generator.py
+++ b/JsonGenerator/source/documentation_generator.py
@@ -759,9 +759,9 @@ def Create(log, schema, path, indent_size = 4):
                     if "locator" in info:
                         commonConfig["locator"] = {"type": "string", "description": 'Library name: *%s*' % info["locator"]}
 
-                    commonConfig["autostart"] = {
-                        "type": "boolean",
-                        "description": "Determines if the plugin shall be started automatically along with the framework"
+                    commonConfig["startmode"] = {
+                        "type": "string",
+                        "description": "Determines in which state the plugin should be moved to at startup of the framework"
                     }
 
                 required = []
@@ -777,7 +777,7 @@ def Create(log, schema, path, indent_size = 4):
                 totalConfig["properties"] = commonConfig2
 
                 if "configuration" not in schema or ("nodefault" not in schema["configuration"] or not schema["configuration"]["nodefault"]):
-                    totalConfig["required"] = ["callsign", "classname", "locator", "autostart"] + required
+                    totalConfig["required"] = ["callsign", "classname", "locator", "startmode"] + required
 
                 ParamTable("", totalConfig)
 

--- a/cmake/FindConfigGenerator.cmake.in
+++ b/cmake/FindConfigGenerator.cmake.in
@@ -235,7 +235,11 @@ if(CMAKE_VERSION VERSION_LESS 3.20.0 AND LEGACY_CONFIG_GENERATOR)
                 endif()
 
                 if (NOT ${autostart} STREQUAL "")
-                    map_append(${plugin_config} autostart ${autostart})
+                    if (${autostart} STREQUAL "false")
+                        map_append(${plugin_config} startmode "Deactivated")
+                    else()
+                        map_append(${plugin_config} startmode "Activated")
+                    endif()
                 endif()
 
                 if (NOT ${resumed} STREQUAL "")


### PR DESCRIPTION
Make sure the AutoStart flag is no longer used or published as it is superseded by the already existing startmode enum together eith the resumed flag (boolean).