### PR TITLE
[StubGen] Intruduce length:return

### DIFF
--- a/ProxyStubGenerator/Log.py
+++ b/ProxyStubGenerator/Log.py
@@ -33,6 +33,22 @@ class Log:
             self.infos.append("%s: %s%s: %s%s%s" % (self.name, self.cinfo, self.creset, file, ": " if file else "", text))
             self.__Print(self.infos[-1])
 
+    def InfoLine(self, obj, text, file=""):
+        if self.show_infos:
+            if not file: file = self.file
+            try:
+                if not file: file = os.path.basename(obj.parser_file)
+                line = str(obj.parser_line)
+            except:
+                try:
+                    file = os.path.basename(obj.parent.parser_file)
+                    line = obj.parent.parser_line
+                except:
+                    file = ""
+                    line = ""
+            self.infos.append("%s: %s%s: %s%s" % (self.name, self.cinfo, self.creset, ("%s(%s): " % (file, line)) if file else "", text))
+            self.__Print(self.infos[-1])
+
     def DocIssue(self, text, file=""):
         if self.show_doc_issues:
             if not file: file = self.file


### PR DESCRIPTION
Adds `@length:return` to be used when the length of a returned buffer is carried on the return value.
This allows for optimizations:
- not sending the entire possible buffer on the inbound message (i.e. from maxlength), but just what was really filled in,
- omitting sending of the result on the inbound message (as the length is already sent within the buffer).

This is used in ICryptography.

Additionally fixed a bug that mixed length with maxlength fixing previously broken `IPerformance::Exchange()`. Additional optimizations are applicable now as above.

Also fixes emitting of some tautology code, making compiler happy.