### PR TITLE
[Actions] Thunder will be the only build required to merge, but Actions will also build other components

### DIFF
--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -11,4 +11,4 @@ jobs:
     uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
 
   ThunderNanoServicesRDK:
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master
+    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -7,8 +7,164 @@ on:
     branches: ["master"]
  
 jobs:
-  ThunderNanoServices:
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
+  ThunderInterfaces:
+    uses: rdkcentral/ThunderInterfaces/.github/workflows/Build ThunderInterfaces on Linux.yml@master
 
-  ThunderNanoServicesRDK:
-    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@development/actions
+  ThunderNanoServices:
+    needs: ThunderInterfaces
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+
+    name: Build type - ${{matrix.build_type}}
+    steps:
+    - name: Install necessary packages
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 10
+        max_attempts: 10
+        command: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
+          sudo apt install python3-pip
+          pip install jsonref
+          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
+
+    - name: Checkout Thunder
+      uses: actions/checkout@v3
+      with:
+        path: Thunder
+        repository: ${{github.repository_owner}}/Thunder
+
+    - name: Checkout ThunderInterfaces
+      uses: actions/checkout@v3
+      with:
+        path: ThunderInterfaces
+        repository: ${{github.repository_owner}}/ThunderInterfaces
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ThunderInterfaces-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}
+
+    - name: Unpack files
+      run: |
+        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+
+    - name: Checkout ThunderNanoServices
+      uses: actions/checkout@v3
+      with:
+        path: ThunderNanoServices
+        repository: ${{github.repository_owner}}/ThunderNanoServices
+
+    - name: Checkout ThunderNanoServicesRDK
+      uses: actions/checkout@v3
+      with:
+        path: ThunderNanoServicesRDK
+        repository: WebPlatformForEmbedded/ThunderNanoServicesRDK
+
+    - name: Checkout ThunderClientLibraries
+      uses: actions/checkout@v3
+      with:
+        path: ThunderClientLibraries
+        repository: ${{github.repository_owner}}/ThunderClientLibraries
+
+    - name: Checkout ThunderLibraries
+      uses: actions/checkout@v3
+      with:
+        path: ThunderLibraries
+        repository: WebPlatformForEmbedded/ThunderLibraries
+
+    - name: Regex ThunderNanoServices
+      if: contains(github.event.pull_request.body, '[Options:')
+      id: plugins
+      uses: AsasInnab/regex-action@v1
+      with:
+        regex_pattern: '(?<=\[Options:).*(?=\])'
+        regex_flags: 'gim'
+        search_string: ${{github.event.pull_request.body}}
+
+    - name: Build ThunderNanoServices
+      run: |
+        cmake -G Ninja -S ThunderNanoServices -B ${{matrix.build_type}}/build/ThunderNanoServices \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DPLUGIN_CECCONTROL=ON \
+        -DPLUGIN_COMMANDER=ON \
+        -DPLUGIN_DHCPSERVER=ON \
+        -DPLUGIN_DIALSERVER=ON \
+        -DPLUGIN_DICTIONARY=ON \
+        -DPLUGIN_FILETRANSFER=ON \
+        -DPLUGIN_IOCONNECTOR=ON \
+        -DPLUGIN_INPUTSWITCH=ON \
+        -DPLUGIN_NETWORKCONTROL=ON \
+        -DPLUGIN_PROCESSMONITOR=ON \
+        -DPLUGIN_RESOURCEMONITOR=ON \
+        -DPLUGIN_SYSTEMCOMMANDS=ON \
+        -DPLUGIN_SWITCHBOARD=ON \
+        -DPLUGIN_WEBPROXY=ON \
+        -DPLUGIN_WEBSERVER=ON \
+        -DPLUGIN_WEBSHELL=ON \
+        -DPLUGIN_WIFICONTROL=ON \
+        ${{steps.plugins.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderNanoServices --target install
+
+    - name: Build ThunderNanoServicesRDK
+      run: |
+        cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DPLUGIN_DEVICEIDENTIFICATION=ON \
+        -DPLUGIN_DEVICEINFO=ON \
+        -DPLUGIN_LOCATIONSYNC=ON \
+        -DPLUGIN_MESSAGECONTROL=ON \
+        -DPLUGIN_MESSENGER=ON \
+        -DPLUGIN_MONITOR=ON \
+        -DPLUGIN_OPENCDMI=ON \
+        -DPLUGIN_PERFORMANCEMETRICS=ON \
+        ${{steps.plugins.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
+
+    - name: Build ThunderClientLibraries
+      run: |
+        cmake -G Ninja -S ThunderClientLibraries -B ${{matrix.build_type}}/build/ThunderClientLibraries \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DBLUETOOTHAUDIOSINK=ON \
+        -DDEVICEINFO=ON \
+        -DDISPLAYINFO=ON \
+        -DLOCALTRACER=ON \
+        -DSECURITYAGENT=ON \
+        -DPLAYERINFO=ON \
+        -DPROTOCOLS=ON \
+        -DVIRTUALINPUT=ON \
+        ${{steps.clientlibs.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderClientLibraries --target install
+
+    - name: Build ThunderLibraries
+      run: |
+        cmake -G Ninja -S ThunderLibraries -B ${{matrix.build_type}}/build/ThunderLibraries \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DBROADCAST=ON \
+        ${{steps.libs.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
+
+    - name: Tar files
+      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: ThunderNanoServices-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}.tar.gz

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -2,10 +2,13 @@ name: Build ThunderTools on Linux
 
 on:
   push:
-    branches: ["master"]
+    # branches: ["master"]
   pull_request:
     branches: ["master"]
  
 jobs:
   ThunderNanoServices:
     uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
+
+  ThunderNanoServicesRDK:
+    uses: rdkcentral/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -7,164 +7,25 @@ on:
     branches: ["master"]
  
 jobs:
+  Thunder:
+    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+
   ThunderInterfaces:
-    uses: rdkcentral/ThunderInterfaces/.github/workflows/Build ThunderInterfaces on Linux.yml@master
+    needs: Thunder
+    uses: VeithMetro/ThunderInterfaces/.github/workflows/Linux build template.yml@development/actions
+
+  ThunderLibraries:
+    needs: Thunder
+    uses: VeithMetro/ThunderLibraries/.github/workflows/Linux build template.yml@development/actions
+
+  ThunderClientLibraries:
+    needs: ThunderInterfaces
+    uses: VeithMetro/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions
 
   ThunderNanoServices:
     needs: ThunderInterfaces
+    uses: VeithMetro/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions
 
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        build_type: [Debug, Release, MinSizeRel]
-
-    name: Build type - ${{matrix.build_type}}
-    steps:
-    - name: Install necessary packages
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 10
-        command: |
-          sudo gem install apt-spy2
-          sudo apt-spy2 fix --commit --launchpad --country=US
-          sudo apt-get update
-          sudo apt install python3-pip
-          pip install jsonref
-          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
-
-    - name: Checkout Thunder
-      uses: actions/checkout@v3
-      with:
-        path: Thunder
-        repository: ${{github.repository_owner}}/Thunder
-
-    - name: Checkout ThunderInterfaces
-      uses: actions/checkout@v3
-      with:
-        path: ThunderInterfaces
-        repository: ${{github.repository_owner}}/ThunderInterfaces
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: ThunderInterfaces-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}
-
-    - name: Unpack files
-      run: |
-        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-
-    - name: Checkout ThunderNanoServices
-      uses: actions/checkout@v3
-      with:
-        path: ThunderNanoServices
-        repository: ${{github.repository_owner}}/ThunderNanoServices
-
-    - name: Checkout ThunderNanoServicesRDK
-      uses: actions/checkout@v3
-      with:
-        path: ThunderNanoServicesRDK
-        repository: WebPlatformForEmbedded/ThunderNanoServicesRDK
-
-    - name: Checkout ThunderClientLibraries
-      uses: actions/checkout@v3
-      with:
-        path: ThunderClientLibraries
-        repository: ${{github.repository_owner}}/ThunderClientLibraries
-
-    - name: Checkout ThunderLibraries
-      uses: actions/checkout@v3
-      with:
-        path: ThunderLibraries
-        repository: WebPlatformForEmbedded/ThunderLibraries
-
-    - name: Regex ThunderNanoServices
-      if: contains(github.event.pull_request.body, '[Options:')
-      id: plugins
-      uses: AsasInnab/regex-action@v1
-      with:
-        regex_pattern: '(?<=\[Options:).*(?=\])'
-        regex_flags: 'gim'
-        search_string: ${{github.event.pull_request.body}}
-
-    - name: Build ThunderNanoServices
-      run: |
-        cmake -G Ninja -S ThunderNanoServices -B ${{matrix.build_type}}/build/ThunderNanoServices \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DPLUGIN_CECCONTROL=ON \
-        -DPLUGIN_COMMANDER=ON \
-        -DPLUGIN_DHCPSERVER=ON \
-        -DPLUGIN_DIALSERVER=ON \
-        -DPLUGIN_DICTIONARY=ON \
-        -DPLUGIN_FILETRANSFER=ON \
-        -DPLUGIN_IOCONNECTOR=ON \
-        -DPLUGIN_INPUTSWITCH=ON \
-        -DPLUGIN_NETWORKCONTROL=ON \
-        -DPLUGIN_PROCESSMONITOR=ON \
-        -DPLUGIN_RESOURCEMONITOR=ON \
-        -DPLUGIN_SYSTEMCOMMANDS=ON \
-        -DPLUGIN_SWITCHBOARD=ON \
-        -DPLUGIN_WEBPROXY=ON \
-        -DPLUGIN_WEBSERVER=ON \
-        -DPLUGIN_WEBSHELL=ON \
-        -DPLUGIN_WIFICONTROL=ON \
-        ${{steps.plugins.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderNanoServices --target install
-
-    - name: Build ThunderNanoServicesRDK
-      run: |
-        cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DPLUGIN_DEVICEIDENTIFICATION=ON \
-        -DPLUGIN_DEVICEINFO=ON \
-        -DPLUGIN_LOCATIONSYNC=ON \
-        -DPLUGIN_MESSAGECONTROL=ON \
-        -DPLUGIN_MESSENGER=ON \
-        -DPLUGIN_MONITOR=ON \
-        -DPLUGIN_OPENCDMI=ON \
-        -DPLUGIN_PERFORMANCEMETRICS=ON \
-        ${{steps.plugins.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
-
-    - name: Build ThunderClientLibraries
-      run: |
-        cmake -G Ninja -S ThunderClientLibraries -B ${{matrix.build_type}}/build/ThunderClientLibraries \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DBLUETOOTHAUDIOSINK=ON \
-        -DDEVICEINFO=ON \
-        -DDISPLAYINFO=ON \
-        -DLOCALTRACER=ON \
-        -DSECURITYAGENT=ON \
-        -DPLAYERINFO=ON \
-        -DPROTOCOLS=ON \
-        -DVIRTUALINPUT=ON \
-        ${{steps.clientlibs.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderClientLibraries --target install
-
-    - name: Build ThunderLibraries
-      run: |
-        cmake -G Ninja -S ThunderLibraries -B ${{matrix.build_type}}/build/ThunderLibraries \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DBROADCAST=ON \
-        ${{steps.libs.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
-
-    - name: Tar files
-      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
-
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: ThunderNanoServices-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}.tar.gz
+  ThunderNanoServicesRDK:
+    needs: ThunderInterfaces
+    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/actions

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -11,4 +11,4 @@ jobs:
     uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
 
   ThunderNanoServicesRDK:
-    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master
+    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@development/actions

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -11,4 +11,4 @@ jobs:
     uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
 
   ThunderNanoServicesRDK:
-    uses: rdkcentral/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml@master

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -7,6 +7,7 @@ on:
     branches: ["master"]
  
 jobs:
+  # change the user and branch name in each one after the templates are merged
   Thunder:
     uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
 

--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderTools on Linux
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
  


### PR DESCRIPTION
Same as with the Thunder PR: https://github.com/rdkcentral/Thunder/pull/1496

This is an initial pull request - the new workflows have to be called from my branches for now (there is a dependency between the workflows), since we need to first merge new templates in each repo. Then, I'll make one more set of pull requests to redirect this new feature to master branches of our repos.

Required checks got updated to the new ones by Stephen.