### PR TITLE
Delimit StubMethods array with nullptr explicitly

### DIFF
--- a/.github/workflows/Build ThunderTools on Linux.yml
+++ b/.github/workflows/Build ThunderTools on Linux.yml
@@ -7,5 +7,25 @@ on:
     branches: ["master"]
  
 jobs:
+  Thunder:
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
+
+  ThunderInterfaces:
+    needs: Thunder
+    uses: rdkcentral/ThunderInterfaces/.github/workflows/Linux build template.yml@master
+
+  ThunderLibraries:
+    needs: Thunder
+    uses: WebPlatformForEmbedded/ThunderLibraries/.github/workflows/Linux build template.yml@main
+
+  ThunderClientLibraries:
+    needs: ThunderInterfaces
+    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@master
+
   ThunderNanoServices:
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Build ThunderNanoServices on Linux.yml@master
+    needs: ThunderInterfaces
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master
+
+  ThunderNanoServicesRDK:
+    needs: ThunderInterfaces
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master

--- a/ConfigGenerator/json_helper.py
+++ b/ConfigGenerator/json_helper.py
@@ -31,18 +31,22 @@ def convert_string(s):
     String will be returned
     """
     if isinstance(s, str):
-        try:
-            val = ast.literal_eval(s)
-            if not isinstance(val, (int, float, str, object)):
-                val = s
-        except:
-            # Let's try if it is JSON Bool values
-            bool_lits = {"true": True, "false": False}
-            if s in bool_lits:
-                val = bool_lits[s]
-            else:
-                val = s
-        return val
+        if s == 'null':
+            val = None
+            return val
+        else:
+            try:
+                val = ast.literal_eval(s)
+                if not isinstance(val, (int, float, str, object)):
+                    val = s
+            except:
+                # Let's try if it is JSON Bool values
+                bool_lits = {"true": True, "false": False}
+                if s in bool_lits:
+                    val = bool_lits[s]
+                else:
+                    val = s
+            return val
     else:
         return s
 

--- a/ConfigGenerator/params.config
+++ b/ConfigGenerator/params.config
@@ -1,4 +1,4 @@
-autostart
+startmode
 callsign
 communicator
 configuration

--- a/DocumentGenerator/DocumentGenerator.py
+++ b/DocumentGenerator/DocumentGenerator.py
@@ -20,72 +20,66 @@
 import argparse
 import sys
 import os
-import glob
 import subprocess
 import shutil
-from git import Repo
 import time
+import re
+from git import Repo
 
-
-THUNDER_REPO_URL = "https://github.com/rdkcentral/Thunder"
-THUNDER_TOOLS_REPO_URL = "https://github.com/rdkcentral/ThunderTools"
-THUNDER_INTERFACE_REPO_URL = "https://github.com/rdkcentral/ThunderInterfaces"
-THUNDER_PLUGINS_REPO_URL = "https://github.com/rdkcentral/ThunderNanoServices.git"
-RDK_PLUGINS_REPO_URL = "https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK.git"
-DOCS_REPO_URL = "https://github.com/WebPlatformForEmbedded/ServicesInterfaceDocumentation.git"
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir))
-import JsonGenerator.JsonGenerator as JsonGenerator
+
 import ProxyStubGenerator.Log as Log
 
 NAME = "DocumentGenerator"
 VERBOSE = True
 SHOW_WARNINGS = True
 DOC_ISSUES = False
-
 log = Log.Log(NAME, VERBOSE, SHOW_WARNINGS, DOC_ISSUES)
+
+DOCS_REPO_URL = "git@github.com:WebPlatformForEmbedded/ServicesInterfaceDocumentation.git"
+THUNDER_REPO_URL = "https://github.com/rdkcentral/Thunder"
+THUNDER_TOOLS_REPO_URL = "https://github.com/rdkcentral/ThunderTools"
+THUNDER_INTERFACE_REPO_URL = "https://github.com/rdkcentral/ThunderInterfaces"
+THUNDER_PLUGINS_REPO_URL = "https://github.com/rdkcentral/ThunderNanoServices.git"
+RDK_PLUGINS_REPO_URL = "https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK.git"
+
+VERSION_PATTERN = re.compile(r'^R\d+\.\d+(\.\d+)?$')
+
 
 class MkdocsYamlFileGenerator():
     def __init__(self, docs_path, site_name, site_url):
-        self._yamlfile_path = docs_path + "mkdocs.yml"
+        self._yamlfile_path = os.path.join(docs_path, "mkdocs.yml")
         self._site_name = site_name
         self._site_url = site_url
         self._current_topic = ""
         self._topic_dict = {}
         self._fd = None
-        return
 
     def create_site_details(self, site_name, site_url):
         assert self._fd != None
         self._fd.write("site_name : " + site_name +"\n")
         self._fd.write("site_url : " + site_url +"\n")
-        return
 
     def add_nav_tag(self):
         assert self._fd != None
         self._fd.write("nav:\n    - 'Documentation': 'index.md'\n")
-        return
-
 
     def add_topic(self, topic_name):
         assert self._fd != None
         self._fd.write("    - '" + topic_name + "':\n")
-        return
 
     def add_subtopic(self, sub_topic_name, markdown_filename):
         assert self._fd != None
         self._fd.write("        - '" + sub_topic_name + "' : '" + markdown_filename +"'\n")
-        return
 
     def create_topics(self, topic_name):
         if topic_name not in self._topic_dict.keys():
             self._topic_dict[topic_name] = []
         self._current_topic = topic_name
-        return
 
     def create_subtopics(self, sub_topic_name, markdown_filename):
         if self._topic_dict[self._current_topic] != None and isinstance(self._topic_dict[self._current_topic], list):
             self._topic_dict[self._current_topic].append((sub_topic_name, markdown_filename))
-        return
 
     def create_file(self):
         self._fd = open(self._yamlfile_path, "w")
@@ -94,13 +88,11 @@ class MkdocsYamlFileGenerator():
         self.add_nav_tag()
         for topic in self._topic_dict:
             self.add_topic(topic)
-            self._topic_dict[topic].sort()
             for subtopic in self._topic_dict[topic]:
                 self.add_subtopic(subtopic[0], subtopic[1])
         self._fd.close()
         self._fd = None
         log.Info("Created %s" % self._yamlfile_path)
-        return
 
     def add_theme_info(self):
         assert self._fd != None
@@ -113,27 +105,30 @@ markdown_extensions:
         emoji_generator: !!python/name:materialx.emoji.to_svg'''
 
         self._fd.write(theme_info + "\n")
-        return
 
 class DocumentGenerator():
-    _yaml_generator = None
-    def __init__(self, thunder_path, thunder_interface_path, thunder_plugins_path, rdk_plugins_path, docs_path, thunder_tools_path):
+    def __init__(self, thunder_path, thunder_interface_path, thunder_plugins_path, rdk_plugins_path, thunder_tools_path, docs_path, local_tools = False):
+        self._local_tools = local_tools
         self.thunder_path = thunder_path
         self.thunder_tools_path = thunder_tools_path
         self.thunder_interface_path = thunder_interface_path
         self.thunder_plugins_path = thunder_plugins_path
         self.rdk_plugins_path = rdk_plugins_path
         self.docs_path = docs_path
+        self.is_branch_name_valid()
         self.clean_all_repos_dir()
         self.clone_all_repos()
-        self._yaml_generator = MkdocsYamlFileGenerator(self.docs_path, "Documentation", "")
+        self._yaml_generator = MkdocsYamlFileGenerator(docs_path=self.docs_path, site_name=branch_name, site_url="")
         self.mkdocs_create_index_file()
+
+    def is_branch_name_valid(self):
+        if not VERSION_PATTERN.fullmatch(branch_name):
+            log.Error("Branch name must be RX.X or RX.X.X where X represents semantic versioning for major.minor or major.minor.patch)")
+            sys.exit()
 
     def clean_all_repos_dir(self):
         if os.path.exists(self.thunder_path):
             shutil.rmtree(self.thunder_path)
-        if os.path.exists(self.thunder_tools_path):
-            shutil.rmtree(self.thunder_tools_path)
         if os.path.exists(self.thunder_interface_path):
             shutil.rmtree(self.thunder_interface_path)
         if os.path.exists(self.thunder_plugins_path):
@@ -142,30 +137,135 @@ class DocumentGenerator():
             shutil.rmtree(self.rdk_plugins_path)
         if os.path.exists(self.docs_path):
             shutil.rmtree(self.docs_path)
-        return
+        if not self._local_tools and os.path.exists(self.thunder_tools_path):
+            shutil.rmtree(self.thunder_tools_path)
 
     def clone_all_repos(self):
+        self.docs_commit_id, self.docs_commit_date = self.clone_repo(DOCS_REPO_URL, self.docs_path)
         self.thunder_commit_id, self.thunder_commit_date = self.clone_repo(THUNDER_REPO_URL, self.thunder_path)
-        self.thunder_tools_commit_id, self.thunder_tools_commit_date = self.clone_repo(THUNDER_TOOLS_REPO_URL, self.thunder_tools_path)
         self.thunder_interfaces_commit_id, self.thunder_interfaces_commit_date = self.clone_repo(THUNDER_INTERFACE_REPO_URL, self.thunder_interface_path)
         self.thunder_plugins_commit_id, self.thunder_plugins_commit_date = self.clone_repo(THUNDER_PLUGINS_REPO_URL, self.thunder_plugins_path)
         self.rdk_plugins_commit_id, self.rdk_plugins_commit_date = self.clone_repo(RDK_PLUGINS_REPO_URL, self.rdk_plugins_path)
-        self.docs_commit_id, self.docs_commit_date = self.clone_repo(DOCS_REPO_URL, self.docs_path)
+
+        if not self._local_tools:
+            self.thunder_tools_commit_id, self.thunder_tools_commit_date = self.clone_repo(THUNDER_TOOLS_REPO_URL, self.thunder_tools_path)
 
     def clone_repo(self, repo_url, local_path):
-        repo = Repo.clone_from(repo_url, local_path)
+        if repo_url == DOCS_REPO_URL:
+            repo = Repo.clone_from(repo_url, local_path, branch="gh-pages")
+            versions = self.collect_existing_versions()
+            sorted_versions = sorted(versions, key=lambda x: list(map(int, x[1:].split('.'))), reverse=True)
+            self.create_root_index(sorted_versions, local_path)
+        else:
+            # Change . with _ as we use underscore for branch names
+            _branch_name = branch_name
+            pattern = re.compile(r'^R\d+\.\d$')
+            if pattern.fullmatch(branch_name):
+                _branch_name = branch_name.replace('.', '_')
+            repo = Repo.clone_from(repo_url, local_path, branch=_branch_name, depth=1)
+
         headcommit = repo.head.commit
         headcommit_sha = headcommit.hexsha
         headcommit_date = time.strftime("%a, %d %b %Y %H:%M", time.gmtime(headcommit.committed_date))
-        log.Info("Repo head: {} ".format( headcommit.hexsha))
-        log.Info("Repo commit date: {}".format( headcommit_date))
+        log.Info("Repo {}".format(repo_url))
+        log.Info("Repo head: {}".format(headcommit.hexsha))
+        log.Info("Repo commit date: {}".format(headcommit_date))
         return (headcommit_sha, headcommit_date)
 
-    def mkdocs_create_index_file(self):
-        if not os.path.exists(self.docs_path + "/docs"):
-            os.mkdir(self.docs_path + "/docs")
+    def collect_existing_versions(self):
+        versions = [d for d in os.listdir(docs_path) if os.path.isdir(os.path.join(docs_path, d)) and VERSION_PATTERN.fullmatch(d)]
+        if branch_name in versions:
+            log.Info("{} has already documented! Do you want to override?".format(branch_name))
+            override = input("Type 'yes' or 'no': ").lower() == "yes"
+            if override:
+                shutil.rmtree(os.path.join(docs_path, branch_name))
 
-        index_file = open(self.docs_path + "/docs/index.md", "w")
+            else:
+                log.Info("Script terminated by user request!")
+                sys.exit()
+        else:
+            versions.append(branch_name)
+
+        return versions
+
+    def create_root_index(self, versions, path):
+
+        html_content = '''
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Documents</title>
+            <style>
+                body {
+                    background-color: #000000;
+                    margin: 0;
+                    padding: 0;
+                    display: flex;
+                    height: 100vh;
+                }
+
+                .container {
+                    text-align: left;
+                    margin-top: 10px;
+                }
+
+                select {
+                    padding: 5px;
+                    font-size: 16px;
+                    border: 1px solid #ccc;
+                    border-radius: 5px;
+                    margin-left: 10px;
+                    margin-bottom: 10px;
+                }
+
+                iframe {
+                    width: 100vw;
+                    height: 95vh;
+                    border: 1px solid #ccc;
+                }
+
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <select id="versionDropdown" onchange="updateFrame()">
+                    <option value="" selected disabled>Select Version</option>
+        '''
+
+        # Populate dropdown options
+        for version in versions:
+            html_content += f'            <option value={version}>{version}</option>\n'
+
+        html_content += '''
+                </select>
+
+                <iframe id="versionFrame" name="versionFrame" src="" frameborder="0"></iframe>
+
+                <script>
+                    document.getElementById("versionDropdown").selectedIndex = 1;
+                    function updateFrame() {
+                        var dropdown = document.getElementById("versionDropdown");
+                        var selectedValue = dropdown.options[dropdown.selectedIndex].value;
+                        var frame = document.getElementById("versionFrame");
+                        frame.src = selectedValue;
+                    }
+                window.onload = updateFrame;
+                </script>
+            </div>
+        </body>
+        </html>
+        '''
+
+        with open('{}/index.html'.format(path), 'w') as file:
+            file.write(html_content)
+
+    def mkdocs_create_index_file(self):
+        if not os.path.exists(os.path.join(self.docs_path, "docs")):
+            os.mkdir(os.path.join(self.docs_path, "docs"))
+
+        index_file = open(os.path.join(self.docs_path, "docs", "index.md"), "w")
         index_file_interface_contents = "# Welcome to Documentation.\nThese documentation are automatically created using mkdocs on " + time.strftime("%a, %d %b %Y %H:%M", time.gmtime()) + " GMT\n\
 ## Interface documentation\nThis section contains the documentation created from interfaces\n\n\
 | Repo | Commit-Id | Commit-Date |\n\
@@ -180,49 +280,39 @@ This section contains the documentation created from plugins\n\n
         index_file.write(index_file_interface_contents)
         index_file.write(index_file_contents_plugins)
 
-    def generate_document(self, schemas):
-        # output_path = "/Users/ksomas586/testPrgs/MarkDown/documentation/out/"
-        output_path = self.docs_path + "/docs/"
-        for schemas_ in schemas:
-          for schema in schemas_:
-            if schema and "info" in schema:
-                warnings = JsonGenerator.config.GENERATED_JSON
-                JsonGenerator.config.GENERATED_JSON = "dorpc" in schema
-                title = schema["info"]["title"] if "title" in schema["info"] \
-                                    else schema["info"]["class"] if "class" in schema["info"] \
-                                    else os.path.basename(output_path)
-
-                if "namespace" in schema["info"]:
-                    title = schema["info"]["namespace"] + title
-
-                try:
-                    path = os.path.join(os.path.dirname(output_path), title.replace(" ", ""))
-                    filename = os.path.basename(os.path.dirname(path) + "/" + os.path.basename(path).replace(".json", "") + ".md")
-                    self._yaml_generator.create_subtopics(title, filename)
-                    JsonGenerator.documentation_generator.Create(log, schema, path)
-                    JsonGenerator.config.GENERATED_JSON = warnings
-                except RuntimeError as err:
-                    log.Error("Error : {}".format( str(err)))
-                except Exception as err:
-                    log.Error("Error : {}".format( str(err)))
-
-    def add_topic(self, topic_name):
+    def add_topic(self, topic_name, path):
+        base = os.path.basename(path)
         self._yaml_generator.create_topics(topic_name)
-        return
 
-    def header_to_markdown(self, path):
-        for file in glob.glob(path):
-            schemas = JsonGenerator.header_loader.LoadInterface(file, log, includePaths=[self.thunder_path + "/Source/"])
-            self.generate_document(schemas)
-        return
+        files = os.listdir(path)
 
-    def json_to_markdown(self, path):
-        for file in glob.glob(path):
-            if file.endswith("common.json"):
-                continue
-            schemas = JsonGenerator.json_loader.LoadSchema(file, thunder_interface_path + "/jsonrpc/", thunder_interface_path + "/interfaces/", [thunder_path + "/Source/"])
-            self.generate_document(schemas)
-        return
+        if files:
+            files.sort(key=str.casefold)
+
+        for f in files:
+            if os.path.isfile(os.path.join(path, f)) and f != "index.md":
+                with open(os.path.join(path, f)) as ff:
+                    lines = ff.readlines()
+                    if lines[2][0] == '#':
+                        title = lines[2][1:].strip()
+                        self._yaml_generator.create_subtopics(title, os.path.join(base, f))
+
+    def to_markdown(self, md_path, include_dirs, cpp_interface_dir, json_interface_dir, paths):
+        cmd = [os.path.join(".", "JsonGenerator.py"), "--docs", "--output", md_path]
+
+        if json_interface_dir:
+            cmd.extend(["-i", json_interface_dir])
+
+        if cpp_interface_dir:
+            cmd.extend(["-j", cpp_interface_dir])
+
+        cmd.extend(paths)
+
+        for i in include_dirs:
+            cmd.extend(["-I", i])
+
+        ret_val = subprocess.run(cmd)
+        log.Info("JsonGenerator exit code: {} ".format(ret_val.returncode))
 
     def complete_yaml_creation(self):
         self._yaml_generator.create_file()
@@ -240,7 +330,7 @@ if __name__ == "__main__":
                             dest="github_deploy",
                             action="store_true",
                             default=False,
-                            help="Deploy generated code in github")
+                            help="Deploy generated code in GitHub")
     argparser.add_argument("--clone_path",
                             dest="clone_path",
                             action="store",
@@ -248,41 +338,79 @@ if __name__ == "__main__":
                             metavar="DIR",
                             required=True,
                             help="Local path for cloning necessary repositories")
+    argparser.add_argument("--branch",
+                            dest="branch_name",
+                            action="store",
+                            default="master",
+                            required=True,
+                            help="Branch name for repositories")
+    argparser.add_argument("--local-tools",
+                            dest="local_tools",
+                            action="store_true",
+                            default=False,
+                            help="Use local tools instead of fetching them from the branch")
 
     args = argparser.parse_args(sys.argv[1:])
+
     clone_path = args.clone_path
     deploy_docs = args.github_deploy
-    thunder_interface_path = clone_path + "/interface/"
-    thunder_plugins_path = clone_path + "/thunder_nano_services/"
-    rdk_plugins_path = clone_path + "/thunder_nano_services_rdk/"
-    thunder_path = clone_path + "/thunder/"
-    thunder_tools_path = clone_path + "/thundertools/"
-    docs_path = clone_path + "/Documentation/"
-    log.Info("Interface path: {} ".format( thunder_interface_path))
-    log.Info("Plugin path: {}".format( thunder_plugins_path))
-    log.Info("RDKPlugin path: {}".format( rdk_plugins_path))
-    log.Info("Thunder path: {}".format( thunder_path))
-    log.Info("Thunder Tools path: {}".format( thunder_tools_path))
-    log.Info("Documentation path: {}".format( docs_path))
+    branch_name = args.branch_name
 
-    document_generator = DocumentGenerator(thunder_path, thunder_interface_path, thunder_plugins_path, rdk_plugins_path, docs_path, thunder_tools_path)
-    os.chdir(thunder_tools_path + "/JsonGenerator/")
+    thunder_interface_path = os.path.join(clone_path, "thunder_interfaces")
+    thunder_plugins_path = os.path.join(clone_path, "thunder_nano_services")
+    rdk_plugins_path = os.path.join(clone_path, "thunder_nano_services_rdk")
+    thunder_path = os.path.join(clone_path, "thunder")
+    docs_path = os.path.join(clone_path, "Documentation")
+
+    if args.local_tools:
+        thunder_tools_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+    else:
+        thunder_tools_path = os.path.join(clone_path, "thunder_tools")
+
+    log.Info("Branch: {}".format(branch_name))
+    log.Info("Thunder path: {}".format(thunder_path))
+    log.Info("Interface path: {}".format(thunder_interface_path))
+    log.Info("NanoServices path: {}".format(thunder_plugins_path))
+    log.Info("RDK NanoServices path: {}".format(rdk_plugins_path))
+    log.Info("Thunder Tools path: {}".format(thunder_tools_path))
+    log.Info("Documentation path: {}".format(docs_path))
+
+    document_generator = DocumentGenerator(thunder_path, thunder_interface_path, thunder_plugins_path, rdk_plugins_path, thunder_tools_path, docs_path, args.local_tools)
+    os.chdir(os.path.join(thunder_tools_path, "JsonGenerator"))
+
+    include_dirs = [os.path.join(thunder_path, "Source")]
+    cpp_interfaces = os.path.join(thunder_interface_path, "interfaces")
+    json_interfaces = os.path.join(thunder_interface_path, "jsonrpc")
+    md_path = os.path.join(docs_path, "docs")
 
     log.Info("Adding Interface Documentation")
-    document_generator.add_topic("Interface Documentation")
-    document_generator.header_to_markdown(thunder_interface_path + "/interfaces/*.h")
-    document_generator.json_to_markdown(thunder_interface_path + "/jsonrpc/*.json")
+    topic = os.path.join(md_path, "api")
+    document_generator.to_markdown(topic, include_dirs, cpp_interfaces, json_interfaces,
+                                   [os.path.join(cpp_interfaces, "*.h"), os.path.join(json_interfaces, "*.json")])
+    document_generator.add_topic("Interface Documentation", topic)
+
     log.Info("Adding Plugin Documentation")
-    document_generator.add_topic("Plugin Documentation")
-    document_generator.json_to_markdown(thunder_plugins_path + "/*/*Plugin.json")
-    document_generator.json_to_markdown(rdk_plugins_path + "/*/*Plugin.json")
+    topic = os.path.join(md_path, "plugins")
+    document_generator.to_markdown(topic, include_dirs, cpp_interfaces, json_interfaces, [os.path.join(thunder_plugins_path, "*", "*Plugin.json")])
+    document_generator.to_markdown(topic, include_dirs, cpp_interfaces, json_interfaces, [os.path.join(rdk_plugins_path, "*", "*Plugin.json")])
+    document_generator.add_topic("Plugin Documentation", topic)
+
     document_generator.complete_yaml_creation()
+
+    try:
+        os.chdir(docs_path)
+        ret_val = subprocess.run(["mkdocs", "build", "-d{}".format(branch_name)])
+        log.Info("mkdocs exit code: {} ".format( ret_val.returncode))
+    except subprocess.CalledProcessError as err:
+        log.Error("Error in creating docs: {}".format( str(err)))
 
     if deploy_docs:
         # unless DOCS_REPO_URL is changed the documentation will be deployed in this location https://webplatformforembedded.github.io/ServicesInterfaceDocumentation/
-        os.chdir(docs_path)
-        try:
-            ret_val = subprocess.run(["mkdocs", "gh-deploy"])
-            log.Info("mkdocs exit code: {} ".format( ret_val.returncode))
-        except subprocess.CalledProcessError as err:
-            log.Error("Error in deploying: {}".format( str(err)))
+        log.Info("Pushing changes to remote!")
+        repo = Repo(docs_path)
+        repo.git.add("index.html")
+        repo.git.add("{}".format(branch_name))
+        repo.index.commit("{} Documentation for ".format(branch_name))
+        repo.remote().push()
+        log.Info("Script Completed Successfully")
+

--- a/JsonGenerator/source/emitter.py
+++ b/JsonGenerator/source/emitter.py
@@ -24,17 +24,20 @@ class Emitter():
         self.lines = []
 
     def __del__(self):
-        if self.file:
-            self.Flush()
-            self.file.close()
+        pass
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        pass
+        if self.file:
+            self.Flush()
+            self.file.close()
 
     def Line(self, text = ""):
+        if "\n" in text:
+            assert("Invalid characters in the emitted line")
+
         if text != "":
             commented = "// " if "//" in text else ""
             text = (" " * self.indent) + str(text)

--- a/JsonGenerator/source/trackers.py
+++ b/JsonGenerator/source/trackers.py
@@ -173,10 +173,11 @@ class ObjectTracker:
             props = newObj.schema["properties"]
             for obj in self.objects[:-1]:
                 if _CompareObject(obj.schema["properties"], props):
-                    if not config.GENERATED_JSON and not config.NO_DUP_WARNINGS and (not is_ref and not IsInRef(obj)):
+                    if not config.GENERATED_JSON and (not is_ref and not IsInRef(obj)):
                         warning = "'%s': duplicate object (same as '%s') - consider using $ref" % (newObj.print_name, obj.print_name)
+
                         if log:
-                            if len(props) > 2:
+                            if not config.NO_DUP_WARNINGS:
                                 log.Warn(warning)
                             else:
                                 log.Info(warning)
@@ -247,9 +248,13 @@ class EnumTracker(ObjectTracker):
             is_ref = IsInRef(newObj)
             for obj in self.objects[:-1]:
                 if __Compare(obj.schema, newObj.schema):
-                    if not config.GENERATED_JSON and not config.NO_DUP_WARNINGS and (not is_ref and not IsInRef(obj)):
-                        log.Warn("'%s': duplicate enums (same as '%s') - consider using $ref" %
-                                   (newObj.print_name, obj.print_name))
+                    if not config.GENERATED_JSON and (not is_ref and not IsInRef(obj)):
+                        warning = "'%s': duplicate enums (same as '%s') - consider using $ref" % (newObj.print_name, obj.print_name)
+
+                        if not config.NO_DUP_WARNINGS:
+                            log.Warn(warning)
+                        else:
+                            log.Info(warning)
 
                     return obj
 

--- a/LuaGenerator/GenerateLua.sh
+++ b/LuaGenerator/GenerateLua.sh
@@ -33,7 +33,7 @@ THUNDER_DIR="${1:-../../Thunder}"
 INTERFACES_DIR="${2:-../../ThunderInterfaces}"
 
 files="$THUNDER_DIR/Source/com/ICOM.h"
-files="$files $THUNDER_DIR/Source/plugins/IController.h $THUNDER_DIR/Source/plugins/IPlugin.h $THUNDER_DIR/Source/plugins/IShell.h $THUNDER_DIR/Source/plugins/IStateControl.h $THUNDER_DIR/Source/plugins/ISubSystem.h $THUNDER_DIR/Source/plugins/IDispatcher.h"
+files="$files $THUNDER_DIR/Source/plugins/IController.h $THUNDER_DIR/Source/plugins/IControllerDeprecated.h $THUNDER_DIR/Source/plugins/IPlugin.h $THUNDER_DIR/Source/plugins/IShell.h $THUNDER_DIR/Source/plugins/IStateControl.h $THUNDER_DIR/Source/plugins/ISubSystem.h $THUNDER_DIR/Source/plugins/IDispatcher.h"
 files="$files $INTERFACES_DIR/interfaces/I*.h"
 # add more interface files if needed..
 

--- a/ProxyStubGenerator/Log.py
+++ b/ProxyStubGenerator/Log.py
@@ -33,6 +33,22 @@ class Log:
             self.infos.append("%s: %s%s: %s%s%s" % (self.name, self.cinfo, self.creset, file, ": " if file else "", text))
             self.__Print(self.infos[-1])
 
+    def InfoLine(self, obj, text, file=""):
+        if self.show_infos:
+            if not file: file = self.file
+            try:
+                if not file: file = os.path.basename(obj.parser_file)
+                line = str(obj.parser_line)
+            except:
+                try:
+                    file = os.path.basename(obj.parent.parser_file)
+                    line = obj.parent.parser_line
+                except:
+                    file = ""
+                    line = ""
+            self.infos.append("%s: %s%s: %s%s" % (self.name, self.cinfo, self.creset, ("%s(%s): " % (file, line)) if file else "", text))
+            self.__Print(self.infos[-1])
+
     def DocIssue(self, text, file=""):
         if self.show_doc_issues:
             if not file: file = self.file

--- a/ProxyStubGenerator/StubGenerator.py
+++ b/ProxyStubGenerator/StubGenerator.py
@@ -1553,6 +1553,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 if not last:
                     emit.Line()
 
+            emit.Line(", nullptr")
             emit.IndentDec()
             emit.Line("}; // %s" % stub_methods_name)
             emit.Line()

--- a/ProxyStubGenerator/StubGenerator.py
+++ b/ProxyStubGenerator/StubGenerator.py
@@ -44,7 +44,7 @@ FORCE = False
 EMIT_COMMENT_WITH_PROTOTYPE = True
 EMIT_COMMENT_WITH_STUB_ORDER = True
 STUB_NAMESPACE = "::WPEFramework::ProxyStubs"
-INTERFACE_NAMESPACE = "::WPEFramework"
+INTERFACE_NAMESPACES = ["::WPEFramework"]
 CLASS_IUNKNOWN = "::WPEFramework::Core::IUnknown"
 PROXYSTUB_CPP_NAME = "ProxyStubs_%s.cpp"
 
@@ -123,14 +123,20 @@ class Interface():
 
 
 # Looks for interface classes (ie. classes inheriting from Core::Unknown and specifying ID enum).
-def FindInterfaceClasses(tree):
+def FindInterfaceClasses(tree, namespace):
     interfaces = []
+    omit_interface_used = False
 
-    def __Traverse(tree, faces):
+    def __Traverse(tree, interface_namespace, faces):
+        nonlocal omit_interface_used
+
         if isinstance(tree, CppParser.Namespace) or isinstance(tree, CppParser.Class):
             for c in tree.classes:
+                if c.omit:
+                    omit_interface_used = True
+
                 if not isinstance(c, CppParser.TemplateClass):
-                    if (c.full_name.startswith(INTERFACE_NAMESPACE + "::")):
+                    if (c.full_name.startswith(interface_namespace + "::")):
                         inherits_iunknown = False
                         for a in c.ancestors:
                             if CLASS_IUNKNOWN in str(a[0]):
@@ -148,24 +154,22 @@ def FindInterfaceClasses(tree):
                                             has_id = True
                                             break
 
-                            if not has_id and not c.omit:
+                            if not has_id:
                                 log.Warn("class %s does not have an ID enumerator" % c.full_name, source_file)
 
-                    elif not c.omit:
-                        log.Info("class %s not in %s namespace" % (c.full_name, INTERFACE_NAMESPACE), source_file)
-
-                __Traverse(c, faces)
+                __Traverse(c, interface_namespace, faces)
 
         if isinstance(tree, CppParser.Namespace):
             for n in tree.namespaces:
-                __Traverse(n, faces)
+                __Traverse(n, namespace, faces)
 
-    __Traverse(tree, interfaces)
-    return interfaces
+    __Traverse(tree, namespace, interfaces)
+
+    return interfaces, omit_interface_used
 
 
 # Cut out scope resolution operators from all identifiers found in a string
-def Flatten(identifier, scope=INTERFACE_NAMESPACE):
+def Flatten(identifier, scope):
     assert scope.startswith("::")
     split = scope.replace(" ", "").split("::")
     split[0] = ("::" + split[1])
@@ -189,12 +193,15 @@ def Flatten(identifier, scope=INTERFACE_NAMESPACE):
 
 
 # Generate interface information in lua
-def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths = [], defaults = "", extra_includes = []):
+def GenerateLuaData(emit, interfaces_list, enums_list, source_file=None, tree=None, ns=None):
 
     if not source_file:
+        assert(tree==None)
+        assert(ns==None)
+
         emit.Line("-- enums")
 
-        for k,v in lua_enums.items():
+        for k,v in enums_list.items():
             emit.Line("ENUMS[\"%s\"] = {" % k)
             emit.IndentInc()
             text = []
@@ -211,22 +218,9 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
 
         return
 
-    files = []
-
-    if defaults:
-        files.append(defaults)
-
-    files.extend(extra_includes)
-    files.append(source_file)
-
-    tree = CppParser.ParseFiles(files, includePaths, log)
-
-    if not isinstance(tree, CppParser.Namespace):
-        raise SkipFileError(source_file)
-
-    interfaces = FindInterfaceClasses(tree)
+    interfaces, _ = FindInterfaceClasses(tree, ns)
     if not interfaces:
-        raise NoInterfaceError(source_file)
+        return []
 
     if not interfaces_list:
         emit.Line("-- Interfaces definition data file")
@@ -237,18 +231,18 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
 
     emit.Line("--  %s" % os.path.basename(source_file))
 
-    iface_namespace_l = INTERFACE_NAMESPACE.split("::")
+    iface_namespace_l = ns.split("::")
     iface_namespace = iface_namespace_l[-1]
 
     for iface in interfaces:
-        iface_name = Flatten(iface.obj.type)
+        iface_name = Flatten(iface.obj.type, ns)
 
         interfaces_var_name = "INTERFACES"
         methods_var_name = "METHODS"
 
         assume_hresult = iface.obj.is_json
 
-        if not iface.obj.full_name.startswith(INTERFACE_NAMESPACE):
+        if not iface.obj.full_name.startswith(ns):
             continue # interface in other namespace
 
         if iface.obj.omit:
@@ -280,7 +274,7 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
             retval = []
             items = [ name ]
 
-            def ParseLength(param, length, vars):
+            def ParseLength(param, length, retval, vars):
                 def _Convert(size):
                     if size == "char":
                         return "8"
@@ -292,6 +286,8 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
                 if len(length) == 1:
                     if length[0] == "void":
                         return [_Convert(param.Type().size), None]
+                    elif length[0] == "return":
+                        return [_Convert(retval.type.Type().size), "return"]
 
                     for v in vars:
                         if v.name == length[0]:
@@ -324,7 +320,7 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
                     length_param = None
 
                     if param.IsPointer():
-                        parsed = ParseLength(param, meta.length if meta.length else meta.maxlength, vars)
+                        parsed = ParseLength(param, meta.length if meta.length else meta.maxlength, retval, vars)
 
                         if parsed[1]:
                             length_param = parsed[1]
@@ -374,7 +370,6 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
                     return ["type = Type.BOOL"]
 
                 elif isinstance(p, CppParser.Float):
-                    print(p)
                     if p.type == "float":
                         return ["type = Type.FLOAT32"]
                     elif p.type == "double":
@@ -382,13 +377,15 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
 
                 elif isinstance(p, CppParser.Class):
                     if param.IsPointer():
-                        return ["type = Type.OBJECT", "class = \"%s\"" % Flatten(param.TypeName())]
+                        return ["type = Type.OBJECT", "class = \"%s\"" % Flatten(param.TypeName(), ns)]
                     else:
-                        value = ["type = Type.POD", "class = \"%s\"" % Flatten(param.type.full_name)]
+                        value = ["type = Type.POD", "class = \"%s\"" % Flatten(param.type.full_name, ns)]
                         pod_params = []
 
-                        for v in p.vars:
-                            param_info = Convert(v, None, p.vars)
+                        kind = p.Merge()
+
+                        for v in kind.vars:
+                            param_info = Convert(v, None, kind.vars)
                             text = []
                             text.append("name = " + v.name)
 
@@ -414,7 +411,7 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
                     if p.type.Type().signed:
                         signed = ""
 
-                    name = Flatten(param.type.full_name)
+                    name = Flatten(param.type.full_name, ns)
 
                     if name not in enums_list:
                         data = dict()
@@ -466,7 +463,15 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
 
                 text.extend(rv)
 
-                retval.append(" { %s }" % ", ".join(text))
+                skip = False
+
+                for v in m.vars:
+                    if (v.meta.length and (v.meta.length[0] == "return")):
+                        skip = True
+                        break
+
+                if not skip:
+                    retval.append(" { %s }" % ", ".join(text))
 
             for p in m.vars:
                 param = Convert(p, m.retval, m.vars)
@@ -480,16 +485,22 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
                     text.extend(param)
 
                     skip = False
+                    skip2 = False
+
                     for v in m.vars:
-                        if (v.meta.length and (v.meta.length[0] == p.name)) and not v.meta.maxlength:
-                            # Will not be on the wire!
+                        if (v.meta.length and (v.meta.length[0] == p.name)):
+                            # Will not be on the wire on inbound!
                             skip = True
 
-                    if not skip:
-                        if p.meta.input or not p.meta.output:
-                            if not skip:
-                                params.append(" { %s }" % ", ".join(text))
+                            if (not v.meta.output or v.meta.input):
+                                # Will not be on the wire on inbound and outbound!
+                                skip2 = True
 
+                    if not skip2:
+                        if p.meta.input or not p.meta.output:
+                            params.append(" { %s }" % ", ".join(text))
+
+                    if not skip:
                         if p.meta.output:
                             retval.append(" { %s }" % ", ".join(text))
 
@@ -506,12 +517,9 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file, includePaths
         emit.Line("}")
         emit.Line()
 
+def Parse(source_file, includePaths = [], defaults = "", extra_includes = []):
 
-def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", extra_includes = [], scan_only=False):
-    log.Info("Parsing '%s'..." % source_file)
-
-    if not FORCE and (os.path.exists(output_file) and (os.path.getmtime(source_file) < os.path.getmtime(output_file))):
-        raise NotModifiedException(output_file)
+    log.Info("Parsing %s..." % source_file)
 
     files = []
 
@@ -525,16 +533,24 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
     if not isinstance(tree, CppParser.Namespace):
         raise SkipFileError(source_file)
 
-    interfaces = FindInterfaceClasses(tree)
+    return tree
+
+def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
+    log.Info("Scanning '%s' (in %s)..." % (source_file, ns))
+
+    if not FORCE and (os.path.exists(output_file) and (os.path.getmtime(source_file) < os.path.getmtime(output_file))):
+        raise NotModifiedException(output_file)
+
+    interfaces, omit_interface_used = FindInterfaceClasses(tree, ns)
     if not interfaces:
-        raise NoInterfaceError(source_file)
+        return [], omit_interface_used
 
     if scan_only:
-        return interfaces
+        return interfaces, omit_interface_used
 
     interface_header_name = os.path.basename(source_file)
 
-    interface_namespace = INTERFACE_NAMESPACE.split("::")[-1]
+    interface_namespace = ns.split("::")[-1]
 
     with open(output_file, "w") as file:
         emit = Emitter(file, INDENT_SIZE)
@@ -546,7 +562,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
         for face in interfaces:
             if not face.obj.omit:
-                emit.Line("//   - %s" % Flatten(str(face.obj)))
+                emit.Line("//   - %s" % Flatten(str(face.obj), ns))
 
         emit.Line("//")
 
@@ -627,16 +643,27 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                     if length_name:
                         if length_name[0] == "void":
                             return EmitIdentifier(-2, interface, \
-                                CppParser.Temporary(self.identifier.parent, ["uint8_t", variable_name], ["sizeof(%s)" % self.kind], []), variable_name)
+                                CppParser.Temporary(self.identifier.parent, ["static constexpr uint8_t", variable_name], ["sizeof(%s)" % self.kind], []), variable_name)
+
+                        elif length_name[0] == "return":
+                            result = "result"
+
+                            if isinstance(self.identifier.parent.retval.type.Type(), CppParser.Integer):
+                                if self.identifier.parent.retval.type.Type().signed:
+                                    result = "(result > 0? result : 0)"
+
+                            return EmitIdentifier(-3, interface, \
+                                CppParser.Temporary(self.identifier.parent, [self.identifier.parent.retval.type, "result"], [result], []), "result")
 
                         elif length_name[0] == "sizeof" and len(length_name) == 4:
                             matches = [v for v in self.identifier.parent.vars if v.name == length_name[2]]
+
                             if matches:
                                 return EmitIdentifier(-2, interface, \
-                                    CppParser.Temporary(self.identifier.parent, ["uint8_t", variable_name], ["sizeof(_%s)" % matches[0].name], []), variable_name)
+                                    CppParser.Temporary(self.identifier.parent, ("static constexpr %s %s" % (length_type, variable_name)).split(), ["sizeof(_%s)" % matches[0].name]), variable_name)
                             else:
                                 return EmitIdentifier(-2, interface, \
-                                    CppParser.Temporary(self.identifier.parent, ["uint8_t", variable_name], ["".join(length_name)], []), variable_name,)
+                                    CppParser.Temporary(self.identifier.parent, ("static constexpr %s %s" % (length_type, variable_name)).split(), ["".join(length_name)]), variable_name)
 
                         matches = [v for v in self.identifier.parent.vars if v.name == "".join(length_name)]
 
@@ -654,7 +681,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                                     length_type = "uint8_t"
 
                                 return EmitIdentifier(-2, interface, \
-                                    CppParser.Temporary(self.identifier.parent, [length_type, variable_name], [str(value)], []), variable_name)
+                                    CppParser.Temporary(self.identifier.parent, ("static constexpr %s %s" % (length_type, variable_name)).split(), [str(value)]), variable_name)
 
                             except (SyntaxError, NameError):
                                 raise TypenameError(self.identifier, "'%s': unable to parse this length expression ('%s')" % (self.trace_proto, "".join(length_name)))
@@ -666,7 +693,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 if not isinstance(identifier.type, CppParser.Type):
                     undefined = CppParser.Type(CppParser.Undefined(identifier.type))
                     if not identifier.parent.stub and not identifier.parent.omit:
-                        raise TypenameError(identifier, "'%s': undefined type" % Flatten(str(" ".join(identifier.type))))
+                        raise TypenameError(identifier, "'%s': undefined type" % Flatten(str(" ".join(identifier.type)), ns))
                     else:
                         type_ = undefined
                 else:
@@ -677,6 +704,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 no_length_warnings = is_variable_length_of
                 is_return_value = (override_name == "result")
 
+                self.is_on_wire = True
                 self.identifier = identifier
                 self.identifier_type = type_
                 self.identifier_kind = self.identifier_type.Type()
@@ -689,7 +717,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 self.is_const = not identifier.meta.output
 
                 # Yields identifier name as in the soruce code, meaningful for a human
-                self.trace_proto = Flatten(self.identifier.Signature())
+                self.trace_proto = Flatten(self.identifier.Signature(), ns)
 
                 if not self.identifier.name.startswith("__unnamed") and \
                         (self.identifier.name.startswith("_") or self.identifier.name.endswith("_")):
@@ -738,30 +766,30 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 self.max_length = _FindLength(self.identifier.meta.maxlength, (name[1:] + "Len"))
 
                 if (is_buffer and not self.length and self.is_input):
-                    raise TypenameError(self.identifier, "'%s': an input raw buffer requires a @length tag" % self.trace_proto)
+                    raise TypenameError(self.identifier, "'%s': an outbound buffer requires a @length tag" % self.trace_proto)
 
                 if (is_buffer and (not self.length and not self.max_length) and self.is_output):
-                    raise TypenameError(self.identifier, "'%s': an output-only raw buffer requires a @maxlength tag" % self.trace_proto)
+                    raise TypenameError(self.identifier, "'%s': an inbound-only buffer requires a @maxlength tag" % self.trace_proto)
 
                 self.is_buffer = ((self.length or self.max_length) and is_buffer)
 
                 # If have a input length, assume it's a max-length parameter even if not stated explicitly
                 if (self.is_buffer and not self.max_length and self.length.is_input):
                     self.max_length = self.length
-                    if self.is_output_only and not self.length.is_output:
-                        # It appears it should've been @maxlength instead of @length... Fix this
-                        self.length = None
-                        log.WarnLine(self.identifier, "'%s': this buffer is output-only, hence expected @maxlength here, not @length" % self.trace_proto)
-                    elif self.is_input and self.is_output:
+
+                    if self.is_input and self.is_output:
                         log.WarnLine(self.identifier, \
-                            "'%s': maximum length of this input/output buffer is assumed to be same as @length, use @maxlength to disambiguate" % \
+                            "'%s': maximum length of this inbound/outbound buffer is assumed to be same as @length, use @maxlength to disambiguate" % \
                                 (self.trace_proto))
+                    elif self.is_output_only:
+                        log.InfoLine(self.identifier, "'%s': @maxlength not specified for this inbound buffer, assuming same as @length" % self.trace_proto)
 
                 if (self.is_buffer and self.is_output and not self.max_length):
-                    raise TypenameError(self.identifier, "'%s': can't deduce maximum length of the buffer, use @maxlength" % self.trace_proto)
+                    raise TypenameError(self.identifier, "'%s': can't deduce maximum length of this inbound buffer, use @maxlength" % self.trace_proto)
 
                 if (self.is_buffer and self.max_length and not self.length):
-                    log.WarnLine(self.identifier, "'%s': length of returned buffer is not specified" % self.trace_proto)
+                    log.WarnLine(self.identifier, "'%s': length of this inbound buffer is not specified; using @maxlength, but this may be inefficient" % self.trace_proto)
+                    self.length = self.max_length
 
                 # Is it a hresult?
                 self.is_hresult = self.identifier_type.TypeName().endswith("Core::hresult") \
@@ -784,13 +812,13 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
                 if has_proxy:
                     # Have to use instance_id instead of the class name
-                    self.type_name = Flatten(self.identifier_type.TypeName())
+                    self.type_name = Flatten(self.identifier_type.TypeName(), ns)
                     self.proto = (("const " if self.is_const else "") + INSTANCE_ID).strip()
                     self.proto_no_cv = INSTANCE_ID
                 else:
-                    self.type_name = Flatten(self.identifier_type.TypeName())
-                    self.proto = Flatten(self.identifier_type.Proto("noref"))
-                    self.proto_no_cv = Flatten(self.identifier_type.Proto("nocv|noref"))
+                    self.type_name = Flatten(self.identifier_type.TypeName(), ns)
+                    self.proto = Flatten(self.identifier_type.Proto("noref"), ns)
+                    self.proto_no_cv = Flatten(self.identifier_type.Proto("nocv|noref"), ns)
 
                 if has_proxy:
                     self.name = ("%sImplementation" % name[1:])
@@ -984,10 +1012,10 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 # Raw buffers
                 elif self.is_buffer:
                     assert self.length or self.max_length, "Invalid type for buffer"
-                    if self.length:
-                        return "Buffer<%s>(%s, %s)" % (self.length.type_name, self.length.as_rvalue, self.as_lvalue)
-                    elif self.max_length:
+                    if self.max_length:
                         return "Buffer<%s>(%s, %s)" % (self.max_length.type_name, self.max_length.as_rvalue, self.as_lvalue)
+                    elif self.length:
+                        return "Buffer<%s>(%s, %s)" % (self.length.type_name, self.length.as_rvalue, self.as_lvalue)
                     else:
                         Unreachable()
 
@@ -1023,7 +1051,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 # Raw buffers
                 elif self.is_buffer:
                     assert self.max_length, "Invalid type for buffer " + self.name
-                    return "Buffer<%s>(%s, %s)" % (self.max_length.type_name, self.max_length.as_rvalue, self.as_rvalue)
+                    return "Buffer<%s>(%s, %s)" % (self.length.type_name, self.length.as_rvalue, self.as_rvalue)
 
                 # Strings
                 elif self.is_string:
@@ -1086,7 +1114,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("// Methods:")
 
                 for index, method in enumerate(methods):
-                    emit.Line("//  (%i) %s" % (index, Flatten(method.Proto())))
+                    emit.Line("//  (%i) %s" % (index, Flatten(method.Proto(), ns)))
 
                 emit.Line("//")
 
@@ -1116,6 +1144,8 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
             for index, var in enumerate(method.vars):
                 params.append(EmitParam(interface, var, index = index))
+                if var.meta.length and var.meta.length[0] == "return":
+                    retval.is_on_wire = False
 
             if retval:
                 output_params.append(retval)
@@ -1145,13 +1175,14 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         # Build the announce list upfront
         for interface in interfaces:
             obj = interface.obj
-            interface_name = Flatten(obj.full_name)
+            interface_name = Flatten(obj.full_name, ns)
 
-            log.Info("Processing '%s' interface data..." % Flatten(obj.type))
+            log.Info("Processing '%s' interface data..." % Flatten(obj.type, ns))
 
-            if not obj.full_name.startswith(INTERFACE_NAMESPACE + "::"):
-                log.Info("class %s not in requested namespace (%s)" % (obj.full_name, INTERFACE_NAMESPACE))
+            if not obj.full_name.startswith(ns + "::"):
+                log.Info("class %s not in requested namespace (%s)" % (obj.full_name, ns))
             elif obj.omit:
+                omit_interface_used = True
                 log.Info("omitting class %s" % interface_name)
             else:
                 # Of course consider only virtual methods
@@ -1219,11 +1250,14 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
             has_hresult = retval and retval.is_hresult
 
             def ReadParameter(p):
+                assert(p)
+                assert(p.is_on_wire)
                 if p.is_compound:
+                    kind = p.kind.Merge()
                     if not p.suppress_type:
                         emit.Line("%s{};" % p.as_temporary_no_cv)
 
-                    params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in p.kind.vars]
+                    params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in kind.vars]
 
                     for pp in params:
                         ReadParameter(pp)
@@ -1247,6 +1281,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                     CheckRange(p, p)
 
             def TemporaryParameter(p):
+                assert(p)
                 if p.is_buffer:
                     output_buffers.append(p)
 
@@ -1257,6 +1292,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 return 0
 
             def AllocateBuffer(p):
+                assert(p)
                 assert p.is_buffer
                 assert p.max_length
 
@@ -1279,8 +1315,11 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
                 if has_buffer_reuse:
                     temp_buffer = AuxIdentifier(CppParser.Void(), CppParser.Ref.POINTER, vars["tempbuffer"])
-                    emit.Line("if (%s > %s) {" % (p.max_length.as_rvalue, p.length.as_rvalue))
-                    emit.IndentInc()
+
+                    if (p.max_length.as_rvalue != p.length.as_rvalue):
+                        emit.Line("if (%s > %s) {" % (p.max_length.as_rvalue, p.length.as_rvalue))
+                        emit.IndentInc()
+
                     emit.Line("%s{};" % temp_buffer.as_temporary_no_cv)
                     emit.Line()
 
@@ -1329,8 +1368,11 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                     emit.Line("}")
                     emit.Line()
                     emit.Line("%s = static_cast<%s>(%s);" % (p.as_rvalue, p.proto, temp_buffer.as_rvalue))
-                    emit.IndentDec()
-                    emit.Line("}")
+
+                    if (p.max_length.as_rvalue != p.length.as_rvalue):
+                        emit.IndentDec()
+                        emit.Line("}")
+
                     emit.Line()
 
                     emit.Line()
@@ -1343,19 +1385,24 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("}")
 
             def ReleaseBuffer(p, large_buffer):
+                assert(p)
                 assert p.is_buffer
                 if (p.max_length and (p.length.type.Type().size == "long")):
                     emit.Line("RPC::Administrator::Instance().Free(%s);" % large_buffer.as_rvalue)
 
             def WriteParameter(p):
-                if p.is_compound:
-                    params = [EmitParam(interface, v, (p.name + "." + v.name)) for v in p.kind.vars]
-                    for pp in params:
-                        WriteParameter(pp)
-                else:
-                    emit.Line("%s.%s;" % (vars["writer"], p.write_rpc_type))
+                assert(p)
+                if p.is_on_wire:
+                    if p.is_compound:
+                        kind = p.kind.Merge()
+                        params = [EmitParam(interface, v, (p.name + "." + v.name)) for v in kind.vars]
+                        for pp in params:
+                            WriteParameter(pp)
+                    else:
+                        emit.Line("%s.%s;" % (vars["writer"], p.write_rpc_type))
 
             def AcquireInterface(p):
+                assert(p)
                 assert p.proxy
                 assert p.proxy_instance
                 emit.Line("%s* %s = nullptr;" %(p.type_name, p.proxy_instance))
@@ -1375,6 +1422,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("}")
 
             def ReleaseProxy(p):
+                assert(p)
                 assert p.proxy
                 emit.Line("if (%s != nullptr) {" % p.proxy)
                 emit.IndentInc()
@@ -1383,6 +1431,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("}")
 
             def RegisterInterface(p):
+                assert(p)
                 assert p.interface_id
                 if not isinstance(p.interface_id, AuxIdentifier):
                     # Interface ID comes from a parameter
@@ -1404,10 +1453,10 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
             if interface.obj.is_iterator:
                 face_name = vars["interface"]
-                emit.Line("using %s = %s;" % (vars["interface"], Flatten(interface.obj.type)))
+                emit.Line("using %s = %s;" % (vars["interface"], Flatten(interface.obj.type, ns)))
                 emit.Line()
             else:
-                face_name = Flatten(interface.obj.type)
+                face_name = Flatten(interface.obj.type, ns)
 
             if ENABLE_INTEGRITY_VERIFICATION:
                 emit.Line("if (%s->Parameters().Length() < (sizeof(%s) + sizeof(uint32_t) + 1)) { return (COM_ERROR | Core::ERROR_READ_ERROR); }" % (vars["message"], INSTANCE_ID))
@@ -1494,7 +1543,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                     emit.Line("%s.Number<uint32_t>(%s);" % (vars["writer"], hresult.as_rvalue))
 
                 emit.Line("fprintf(stderr, \"COM-RPC stub 0x%%08x(%%u) failed: 0x%%08x\\n\", %s, %s, %s);" \
-                                % (Flatten(interface.obj.type) + "::ID", index, hresult.as_rvalue))
+                                % (Flatten(interface.obj.type, ns) + "::ID", index, hresult.as_rvalue))
 
                 if not has_hresult:
                     emit.Line("TRACE_L1(\"Warning: This COM-RPC failure will not propagate!\");")
@@ -1503,14 +1552,14 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("}")
 
             if has_restricted_parameters and (not retval or not retval.is_hresult):
-                log.WarnLine(method, "'%s': method is using restricted parameters but its return value type is not 'Core::hresult'" % method.name)
+                log.InfoLine(method, "'%s': method is using restricted parameters, but its return value type is not 'Core::hresult'" % method.name)
 
         def EmitStubMethod(index, last, method, interface_name, interface, prepared_params):
             retval, params, input_params, output_params, proxy_params, return_proxy_params = prepared_params
 
             channel = "/* channel */" if method.stub or (not proxy_params and not return_proxy_params and not ENABLE_INSTANCE_VERIFICATION) else vars["channel"]
             message = "/* message */" if method.stub else vars["message"]
-            emit.Line("// (%i) %s" % (index, Flatten(method.Proto())))
+            emit.Line("// (%i) %s" % (index, Flatten(method.Proto(), ns)))
             emit.Line("//")
             emit.Line("[](Core::ProxyType<Core::IPCChannel>& %s, Core::ProxyType<RPC::InvokeMessage>& %s) {" % (channel, message))
             emit.IndentInc()
@@ -1534,7 +1583,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
         def EmitStub(interface_name, methods, stub_methods_name, interface, prepared_params):
             if BE_VERBOSE:
-                log.Print("Emitting stub code for interface %s..." % Flatten(interface.obj.type))
+                log.Print("Emitting stub code for interface %s..." % Flatten(interface.obj.type, ns))
 
             # Emit class summary
             emit.Line("//")
@@ -1619,8 +1668,11 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
             emit.Line()
 
             def WriteParameter(p):
+                assert(p)
+                assert(p.is_on_wire)
                 if p.is_compound:
-                    params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in p.kind.vars]
+                    kind = p.kind.Merge()
+                    params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in kind.vars]
 
                     for pp in params:
                         WriteParameter(pp)
@@ -1628,34 +1680,37 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                     emit.Line("writer.%s;" % p.write_rpc_type)
 
             def ReadParameter(p):
-                if p.is_compound:
-                    params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in p.kind.vars]
-                    for pp in params:
-                        ReadParameter(pp)
+                assert(p)
+                if p.is_on_wire:
+                    if p.is_compound:
+                        kind = p.kind.Merge()
+                        params = [EmitParam(interface, v, (p.name + "." + v.name), True) for v in kind.vars]
+                        for pp in params:
+                            ReadParameter(pp)
 
-                elif p.return_proxy:
-                    emit.Line("%s = reinterpret_cast<%s>(Interface(%s.%s, %s));" % \
-                              (p.as_lvalue, p.proto_no_cv, vars["reader"], p.read_rpc_type, p.interface_id.as_rvalue))
+                    elif p.return_proxy:
+                        emit.Line("%s = reinterpret_cast<%s>(Interface(%s.%s, %s));" % \
+                                (p.as_lvalue, p.proto_no_cv, vars["reader"], p.read_rpc_type, p.interface_id.as_rvalue))
 
-                elif p.is_buffer:
-                    CheckFrame(p)
-                    CheckSize(p)
+                    elif p.is_buffer:
+                        CheckFrame(p)
+                        CheckSize(p)
 
-                    if p.length:
-                        emit.Line("%s = %s.%s;" % (p.length.as_lvalue, vars["reader"], p.read_rpc_type))
+                        if p.length and p.length.is_output:
+                            emit.Line("%s = %s.%s;" % (p.length.as_lvalue, vars["reader"], p.read_rpc_type))
+                        else:
+                            # No one's interested in the return length, perhaps it's sent via method's return value
+                            emit.Line("%s.%s;" % (vars["reader"], p.read_rpc_type))
+
+                    elif p.is_string:
+                        CheckFrame(p)
+                        CheckSize(p)
+                        emit.Line("%s = %s.%s;" % (p.as_lvalue, vars["reader"], p.read_rpc_type))
+
                     else:
-                        # No one's interested in the return length, perhaps it's sent via method's return value
-                        emit.Line("%s.%s;" % (vars["reader"], p.read_rpc_type))
-
-                elif p.is_string:
-                    CheckFrame(p)
-                    CheckSize(p)
-                    emit.Line("%s = %s.%s;" % (p.as_lvalue, vars["reader"], p.read_rpc_type))
-
-                else:
-                    CheckFrame(p)
-                    emit.Line("%s = %s.%s;" % (p.as_lvalue, vars["reader"], p.read_rpc_type))
-                    CheckRange(p, p)
+                        CheckFrame(p)
+                        emit.Line("%s = %s.%s;" % (p.as_lvalue, vars["reader"], p.read_rpc_type))
+                        CheckRange(p, p)
 
             if input_params:
                 emit.Line("RPC::Data::Frame::Writer %s(%s->Parameters().Writer());" % (vars["writer"], vars["message"]))
@@ -1747,7 +1802,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
                 emit.Line("if ((%s & COM_ERROR) != 0) {" % hresult.as_rvalue)
                 emit.IndentInc()
                 emit.Line("fprintf(stderr, \"COM-RPC call 0x%%08x(%%u) failed: 0x%%08x\\n\", %s, %s, %s);" \
-                                % (Flatten(interface.obj.type) + "::ID", index, hresult.as_rvalue))
+                                % (Flatten(interface.obj.type, ns) + "::ID", index, hresult.as_rvalue))
 
                 if not reuse_hresult:
                     emit.Line("TRACE_L1(\"Warning: This COM-RPC failure will not propagate!\");")
@@ -1771,9 +1826,9 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         def EmitProxyMethod(index, method, interface_name, interface, prepared_params):
             retval, params, input_params, output_params, proxy_params, return_proxy_params = prepared_params
 
-            method_type = ((Flatten(retval.identifier.Proto()) + " ") if retval else "void ")
+            method_type = ((Flatten(retval.identifier.Proto(), ns) + " ") if retval else "void ")
             method_qualifiers = ((" const" if "const" in method.qualifiers else "") + " override")
-            params_list = [(Flatten(p.identifier.Proto()) + ((" " + p.as_in_prototype) if not method.stub else "")) for p in params]
+            params_list = [(Flatten(p.identifier.Proto(), ns) + ((" " + p.as_in_prototype) if not method.stub else "")) for p in params]
             emit.Line("%s%s(%s)%s" % (method_type, method.name, ", ".join(params_list), method_qualifiers))
             emit.Line("{")
             emit.IndentInc()
@@ -1801,7 +1856,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
 
         def EmitProxy(interface_name, methods, proxy_name, interface, prepared_params):
             if BE_VERBOSE:
-                log.Print("Emitting proxy code for interface %s..." % Flatten(interface.obj.type))
+                log.Print("Emitting proxy code for interface %s..." % Flatten(interface.obj.type, ns))
 
             # Emit class summary
             emit.Line("//")
@@ -1811,7 +1866,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
             emit.Line()
 
             # Emit proxy class definition
-            emit.Line("class %s final : public ProxyStub::UnknownProxyType<%s> {" % (proxy_name, Flatten(interface.obj.type)))
+            emit.Line("class %s final : public ProxyStub::UnknownProxyType<%s> {" % (proxy_name, Flatten(interface.obj.type, ns)))
             emit.Line("public:")
             emit.IndentInc()
 
@@ -1855,7 +1910,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         emit.Line()
 
         for _, [_, methods, stub, _, interface, _ ] in announce_list.items():
-            emit.Line("typedef ProxyStub::UnknownStubType<%s, %s> %s;" % (Flatten(interface.obj.type), methods, stub))
+            emit.Line("typedef ProxyStub::UnknownStubType<%s, %s> %s;" % (Flatten(interface.obj.type, ns), methods, stub))
 
         emit.Line()
 
@@ -1867,13 +1922,13 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         emit.IndentInc()
 
         if EMIT_TRACES:
-            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods...\\n\");" % Flatten(interface.obj.type))
+            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods...\\n\");" % Flatten(interface.obj.type, ns))
 
         for _, [_, _, stub, proxy, interface, _ ]  in announce_list.items():
-            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" % (Flatten(interface.obj.type), proxy, stub))
+            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" % (Flatten(interface.obj.type, ns), proxy, stub))
 
         if EMIT_TRACES:
-            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods... done\\n\");" % Flatten(interface.obj.type))
+            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods... done\\n\");" % Flatten(interface.obj.type, ns))
 
         emit.IndentDec()
         emit.Line("}")
@@ -1883,13 +1938,13 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         emit.IndentInc()
 
         if EMIT_TRACES:
-            emit.Line("fprintf(stderr, \"*** Recalling %s interface methods...\\n\");" % Flatten(interface.obj.type))
+            emit.Line("fprintf(stderr, \"*** Recalling %s interface methods...\\n\");" % Flatten(interface.obj.type, ns))
 
         for _, [_, _, _, _, interface, _ ]  in announce_list.items():
-            emit.Line("RPC::Administrator::Instance().Recall<%s>();" % (Flatten(interface.obj.type)))
+            emit.Line("RPC::Administrator::Instance().Recall<%s>();" % (Flatten(interface.obj.type, ns)))
 
         if EMIT_TRACES:
-            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods... done\\n\");" % Flatten(interface.obj.type))
+            emit.Line("fprintf(stderr, \"*** Announcing %s interface methods... done\\n\");" % Flatten(interface.obj.type, ns))
 
         emit.IndentDec()
         emit.Line("}")
@@ -1906,7 +1961,7 @@ def GenerateStubs2(output_file, source_file, includePaths = [], defaults = "", e
         emit.Line()
         emit.Line("}") # // namespace %s" % STUB_NAMESPACE.split("::")[-1])
 
-    return interfaces
+    return interfaces, omit_interface_used
 
 def GenerateIdentification(name):
     if not os.path.exists(name):
@@ -1933,10 +1988,10 @@ def GenerateIdentification(name):
             if not options:
                 options.append("0")
 
-            emit.Line("EXTERNAL proxystubs_options_t proxystubs_options()")
+            emit.Line("EXTERNAL_EXPORT proxystubs_options_t proxystubs_options()")
             emit.Line("{")
             emit.IndentInc()
-            emit.Line("return (static_cast<proxystubs_options_t>(%s));" % " & ".join(options))
+            emit.Line("return (static_cast<proxystubs_options_t>(%s));" % " | ".join(options))
             emit.IndentDec()
             emit.Line("}")
             emit.IndentDec()
@@ -1991,12 +2046,11 @@ if __name__ == "__main__":
                            default=False,
                            help="emit additional debug traces (default: no extra traces)")
     argparser.add_argument("--namespace",
-                           dest="if_namespace",
+                           dest="if_namespaces",
                            metavar="NS",
-                           type=str,
-                           action="store",
-                           default=INTERFACE_NAMESPACE,
-                           help="set the namespace to look for interfaces in (default: %s)" % INTERFACE_NAMESPACE)
+                           action="append",
+                           default=[],
+                           help="set a namespace to look for interfaces in (default: %s)" % INTERFACE_NAMESPACES[0])
     argparser.add_argument("--outdir",
                            dest="outdir",
                            metavar="DIR",
@@ -2042,14 +2096,17 @@ if __name__ == "__main__":
     ENABLE_SECURE = ENABLE_INSTANCE_VERIFICATION or ENABLE_RANGE_VERIFICATION or ENABLE_INTEGRITY_VERIFICATION
     log.show_infos = BE_VERBOSE
     log.show_warnings = SHOW_WARNINGS
-    INTERFACE_NAMESPACE = args.if_namespace
     OUTDIR = args.outdir
     EMIT_TRACES = args.traces
     scan_only = False
     keep_incomplete = args.keep_incomplete
 
-    if INTERFACE_NAMESPACE[0:2] != "::":
-        INTERFACE_NAMESPACE = "::" + INTERFACE_NAMESPACE
+    if args.if_namespaces:
+        INTERFACE_NAMESPACES = args.if_namespaces
+
+    for i, ns in enumerate(INTERFACE_NAMESPACES):
+        if not ns.startswith("::"):
+            INTERFACE_NAMESPACES[i] = "::" + ns
 
     if args.help_tags:
         print("The following special tags are supported:")
@@ -2058,7 +2115,7 @@ if __name__ == "__main__":
         print("   @stub                  - generate an empty stub for the next item (class or method)")
         print("   @insert \"file\"         - include a C++ header file, relative to the directory of the current file")
         print("   @insert <file>         - include a C++ header file, relative to the defined include directories")
-        print("                            note: this is intended for resolving unknown types, classes defined in included")
+        print("                            note: this is intended for resolving unknown types; classes defined in included")
         print("                            headers are not considered for stub generation (except for template classes)")
         print("   @define {identifier}   - defines a literal as a known identifier (equivalent of #define {identifier} in C++ code)")
         print("")
@@ -2067,12 +2124,16 @@ if __name__ == "__main__":
         print("   @out                   - indicates an output parameter")
         print("   @inout                 - indicates an input/output parameter (equivalent of @in @out)")
         print("   @restrict              - specifies valid range for a parameter (for buffers and strings: valid size)")
-        print("                            e.g.: @restrict:1..32, @restrict:256..1K, @restrict:1M")
+        print("                            e.g.: @restrict:1..32, @restrict:256..1K, @restrict:1M-1")
         print("   @interface:{expr}      - specifies a parameter or value indicating interface ID value for void* interface passing")
         print("   @length:{expr}         - specifies a buffer length value (a constant, a parameter name or a math expression)")
         print("   @maxlength:{expr}      - specifies a maximum buffer length value (a constant, a parameter name or a math expression),")
-        print("                            if not specified, @length is considered as maximum length; use round parenthesis for expressions",)
-        print("                            e.g.: @length:bufferSize @length:(width*height*4), @length:(sizeof(uint64_t)), @length:void")
+        print("                            if @maxlength is not specified, expresion from @length is used")
+        print("")
+        print("                            Examples:")
+        print("                            @length:bufferSize, @length:32, @length:(width*height*4), @length:(sizeof(uint64_t))")
+        print("                            @length:return - length is carried in the return value")
+        print("                            @length:void - length is the size of one element")
         print("")
         print("JSON-RPC-related parameters:")
         print("   @json                  - takes a C++ class in for JSON-RPC generation")
@@ -2086,6 +2147,8 @@ if __name__ == "__main__":
         print("   @bitmask               - indicates that enumerator lists should be packed into into a bit mask")
         print("   @index                 - indicates that a parameter in a JSON-RPC property or notification is an index")
         print("   @opaque                - indicates that a string parameter is an opaque JSON object")
+        print("   @extract               - indicates that that if only one element is present in the array it shall be taken out of it")
+        print("   @optional              - indicates that a parameter, struct member or property index is optional")
         print("   @prefix {name}         - prefixes all JSON-RPC methods, properties and notifications names in an interface with a string")
         print("   @text {name}           - sets a different name for a parameter, enumerator, struct or JSON-RPC method, property or notification")
         print("   @alt {name}            - provides an alternative name a JSON-RPC method or property can by called by")
@@ -2101,6 +2164,7 @@ if __name__ == "__main__":
         print("   @details {desc}        - sets a detailed description for a JSON-RPC method, property or notification")
         print("   @param {name} {desc}   - sets a description for a parameter of a JSON-RPC method or notification")
         print("   @retval {desc}         - sets a description for a return value of a JSON-RPC method")
+        print("   @end                   - indicates end of the enumerator list (don't document further)")
         print("")
         print("Tags shall be placed inside C++ comments.")
         sys.exit()
@@ -2157,6 +2221,10 @@ if __name__ == "__main__":
                     _extra_includes = [ os.path.join("@" + os.path.dirname(source_file), IDS_DEFINITIONS_FILE) ]
                     _extra_includes.extend(args.extra_includes)
 
+                    tree = Parse(source_file, args.includePaths,
+                                    os.path.join("@" + os.path.dirname(os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE),
+                                    _extra_includes)
+
                     if args.code:
                         log.Header(source_file)
 
@@ -2167,16 +2235,23 @@ if __name__ == "__main__":
                         if not os.path.exists(out_dir):
                             os.makedirs(out_dir)
 
-                        output = GenerateStubs2(
-                            output_file, source_file,
-                            args.includePaths,
-                            os.path.join("@" + os.path.dirname(os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE),
-                            _extra_includes,
-                            scan_only)
+                        new_faces = []
+                        some_omitted = False
 
-                        faces += output
+                        for ns in INTERFACE_NAMESPACES:
+                            output, some_omitted = GenerateStubs2(output_file, source_file, tree, ns, scan_only)
 
-                        log.Print("created file %s" % os.path.basename(output_file))
+                            new_faces += output
+
+                        if not new_faces:
+                            if not some_omitted:
+                                raise NoInterfaceError
+                            else:
+                                log.Info("no interface classes found")
+
+                        else:
+                            faces += new_faces
+                            log.Print("created file %s" % os.path.basename(output_file))
 
                         # dump interfaces if only scanning
                         if scan_only:
@@ -2185,9 +2260,9 @@ if __name__ == "__main__":
 
                     if args.lua_code:
                         log.Print("(lua generator) Scanning %s..." % os.path.basename(source_file))
-                        GenerateLuaData(Emitter(lua_file, INDENT_SIZE), lua_interfaces, lua_enums, source_file, args.includePaths,
-                            os.path.join("@" + os.path.dirname(os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE),
-                            _extra_includes)
+
+                        for ns in INTERFACE_NAMESPACES:
+                            GenerateLuaData(Emitter(lua_file, INDENT_SIZE), lua_interfaces, lua_enums, source_file, tree, ns)
 
                 except NotModifiedException as err:
                     log.Print("skipped file %s, up-to-date" % os.path.basename(output_file))
@@ -2196,7 +2271,7 @@ if __name__ == "__main__":
                     log.Print("skipped file %s" % os.path.basename(output_file))
                     skipped.append(source_file)
                 except NoInterfaceError as err:
-                    log.Warn("no interface classes found in %s" % (INTERFACE_NAMESPACE), os.path.basename(source_file))
+                    log.Warn("no interface classes found")
                 except TypenameError as err:
                     log.Error(err)
                     if not keep_incomplete and os.path.isfile(output_file):
@@ -2237,8 +2312,9 @@ if __name__ == "__main__":
 
             if args.lua_code:
                 # Epilogue
-                GenerateLuaData(Emitter(lua_file, INDENT_SIZE), lua_interfaces, lua_enums, None)
-                log.Print("Created %s (%s interfaces, %s enums)" % (lua_file.name, len(lua_interfaces), len(lua_enums)))
+                for ns in INTERFACE_NAMESPACES:
+                    GenerateLuaData(Emitter(lua_file, INDENT_SIZE), lua_interfaces, lua_enums)
+                    log.Print("Created %s (%s interfaces, %s enums)" % (lua_file.name, len(lua_interfaces), len(lua_enums)))
 
         else:
             log.Print("Nothing to do")

--- a/ProxyStubGenerator/default.h
+++ b/ProxyStubGenerator/default.h
@@ -47,7 +47,7 @@ namespace std {
 namespace WPEFramework {
 
   namespace Core {
-    typedef __stubgen_integer instance_id;
+    typedef __stubgen_instance_id instance_id;
     typedef uint32_t hresult;
 
     struct IUnknown {

--- a/cmake/FindConfigGenerator.cmake.in
+++ b/cmake/FindConfigGenerator.cmake.in
@@ -235,7 +235,11 @@ if(CMAKE_VERSION VERSION_LESS 3.20.0 AND LEGACY_CONFIG_GENERATOR)
                 endif()
 
                 if (NOT ${autostart} STREQUAL "")
-                    map_append(${plugin_config} autostart ${autostart})
+                    if (${autostart} STREQUAL "false")
+                        map_append(${plugin_config} startmode "Deactivated")
+                    else()
+                        map_append(${plugin_config} startmode "Activated")
+                    endif()
                 endif()
 
                 if (NOT ${resumed} STREQUAL "")

--- a/cmake/FindJsonGenerator.cmake.in
+++ b/cmake/FindJsonGenerator.cmake.in
@@ -30,9 +30,9 @@ function(JsonGenerator)
         message(FATAL_ERROR "JsonGenerator path ${JSON_GENERATOR} invalid.")
     endif()
 
-    set(optionsArgs CODE STUBS DOCS NO_INCLUDES NO_STYLE_WARNINGS COPY_CTOR NO_REF_NAMES NO_INTERFACES_SECTION VERBOSE FORCE_GENERATE)
-    set(oneValueArgs OUTPUT IFDIR CPPIFDIR INDENT DEF_STRING DEF_INT_SIZE PATH FORMAT NAMESPACE)
-    set(multiValueArgs INPUT INCLUDE_PATH)
+    set(optionsArgs CODE STUBS DOCS LEGACY_ALT AUTO_PREFIX NO_INCLUDES NO_WARNINGS NO_STYLE_WARNINGS DUPLICATE_OBJ_WARNINGS COPY_CTOR NO_REF_NAMES NO_INTERFACES_SECTION VERBOSE FORCE_GENERATE EMIT_INTERFACE_PATH )
+    set(oneValueArgs OUTPUT CPP_OUTPUT IFDIR CPPIFDIR INDENT DEF_STRING DEF_INT_SIZE PATH FORMAT CPP_INTERFACE_PATH JSON_INTERFACE_PATH)
+    set(multiValueArgs INPUT INCLUDE_PATH NAMESPACE)
 
     cmake_parse_arguments(Argument "${optionsArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -56,12 +56,28 @@ function(JsonGenerator)
         list(APPEND _execute_command  "--docs")
     endif()
 
+    if(Argument_LEGACY_ALT)
+        list(APPEND _execute_command  "--legacy-alt")
+    endif()
+
+    if(Argument_AUTO_PREFIX)
+        list(APPEND _execute_command  "--auto-prefix")
+    endif()
+
     if(Argument_NO_INCLUDES)
         list(APPEND _execute_command  "--no-includes")
     endif()
 
+    if(Argument_NO_WARNINGS)
+        list(APPEND _execute_command  "--no-warnings")
+    endif()
+
     if(Argument_NO_STYLE_WARNINGS)
         list(APPEND _execute_command  "--no-style-warnings")
+    endif()
+
+    if(DUPLICATE_OBJ_WARNINGS)
+        list(APPEND _execute_command  "--duplicate-obj-warnings")
     endif()
 
     if(Argument_COPY_CTOR)
@@ -84,6 +100,10 @@ function(JsonGenerator)
         list(APPEND _execute_command  "--force")
     endif()
 
+    if(Argument_EMIT_INTERFACE_PATH)
+        list(APPEND _execute_command  "--emit-cpp-interface-path")
+    endif()
+
     if (Argument_PATH)
         list(APPEND _execute_command  "-p" "${Argument_PATH}")
     endif()
@@ -101,6 +121,11 @@ function(JsonGenerator)
         list(APPEND _execute_command  "--output" "${Argument_OUTPUT}")
     endif()
 
+    if (Argument_CPP_OUTPUT)
+        file(MAKE_DIRECTORY "${Argument_CPP_OUTPUT}")
+        list(APPEND _execute_command  "--cpp-output" "${Argument_CPP_OUTPUT}")
+    endif()
+
     if (Argument_INDENT)
         list(APPEND _execute_command  "--indent" "${Argument_INDENT}")
     endif()
@@ -112,9 +137,17 @@ function(JsonGenerator)
     if (Argument_DEF_INT_SIZE)
         list(APPEND _execute_command  "--def-int-size" "${Argument_DEF_INT_SIZE}")
     endif()
-
+    
     if (Argument_FORMAT)
         list(APPEND _execute_command "--format" "${Argument_FORMAT}")
+    endif()
+    
+    if (Argument_CPP_INTERFACE_PATH)
+        list(APPEND _execute_command "--emit-cpp-interface-path" "${Argument_CPP_INTERFACE_PATH}")
+    endif()
+    
+    if (Argument_JSON_INTERFACE_PATH)
+        list(APPEND _execute_command "--emit-json-interface-path" "${Argument_JSON_INTERFACE_PATH}")
     endif()
 
     if (Argument_NAMESPACE)

--- a/cmake/FindProxyStubGenerator.cmake.in
+++ b/cmake/FindProxyStubGenerator.cmake.in
@@ -31,8 +31,8 @@ function(ProxyStubGenerator)
     endif()
 
     set(optionsArgs SECURE COHERENT TRACES VERBOSE NO_WARNINGS KEEP FORCE_GENERATE)
-    set(oneValueArgs NAMESPACE OUTDIR)
-    set(multiValueArgs INPUT INCLUDE INCLUDE_PATH)
+    set(oneValueArgs OUTDIR)
+    set(multiValueArgs INPUT INCLUDE INCLUDE_PATH NAMESPACE)
 
     cmake_parse_arguments(Argument "${optionsArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 


### PR DESCRIPTION
This change is made so that the below code in UnknownStubType doesn't accidentally walk over any data (that might be initialized with non-zero value)

   ```
 template <typename INTERFACE, MethodHandler METHODS[]>
    class UnknownStubType : public UnknownStub {
        ...
        UnknownStubType()
        {
            _myHandlerCount = 0;

            while (METHODS[_myHandlerCount] != nullptr) {
                _myHandlerCount++;
            }
        }
        ...
     } 
```


This issue was identified by AddressSanitizer as below
```
==30==ERROR: AddressSanitizer: global-buffer-overflow on address 0xe3815db8 at pc 0xe37e9105 bp 0xffaf6008 sp 0xffaf600c
READ of size 4 at 0xe3815db8 thread T0
    #0 0xe37e9102  (/usr/libexec/asan_lib/usr/lib/libWPEFrameworkCOM.so.4+0x59102)
    #1 0xe37a740a  (/usr/libexec/asan_lib/usr/lib/libWPEFrameworkCOM.so.4+0x1740a)

0xe3815db8 is located 0 bytes to the right of global variable 'RPCIteratorTypeInstance3383739DStubMethods' defined in '/mnt/jenkins/workspace/SERCOMMXIONE-Krikstone-Yocto-Build/build-xione-sercomm/tmp/work/armv7vet2hf-neon-rdkmllib32-linux-gnueabi/lib32-wpeframework/4.4-r0/build/Source/com/generated/ProxyStubs_COM.cpp:41:30' (0xe3815da0) of size 24
SUMMARY: AddressSanitizer: global-buffer-overflow (/usr/libexec/asan_lib/usr/lib/libWPEFrameworkCOM.so.4+0x59102)
Shadow bytes around the buggy address:
  0x3c702b60: f9 f9 f9 f9 00 00 00 00 00 00 00 f9 f9 f9 f9 f9
  0x3c702b70: 01 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x3c702b80: 00 00 00 00 00 00 00 f9 f9 f9 f9 f9 01 f9 f9 f9
  0x3c702b90: f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9 00 04 f9 f9
  0x3c702ba0: f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9
=>0x3c702bb0: f9 f9 f9 f9 00 00 00[f9]f9 f9 f9 f9 00 00 00 00
  0x3c702bc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x3c702bd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x3c702be0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x3c702bf0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x3c702c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==30==ABORTING
==30==Sleeping for 30 second(s)
```


```
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:46
#1  0xe6bb2124 in __GI___clock_nanosleep_time64 (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0xffaed168, rem=0xffaed178) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:62
#2  0xe6bb5956 in __GI___nanosleep64 (rem=<optimized out>, req=0xffaed168) at ../sysdeps/unix/sysv/linux/nanosleep.c:25
#3  __GI___nanosleep (req=req@entry=0xffaed190, rem=rem@entry=0xffaed190) at ../sysdeps/unix/sysv/linux/nanosleep.c:42
#4  0xe6bb587a in __sleep (seconds=0) at ../sysdeps/posix/sleep.c:55
#5  0xf7363d38 in __asan::AsanDie () at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/asan/asan_rtl.cpp:52
#6  __asan::AsanDie () at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/asan/asan_rtl.cpp:42
#7  0xf7373d4a in __sanitizer::Die () at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/sanitizer_common/sanitizer_termination.cpp:55
#8  0xf7363bd8 in __asan::ScopedInErrorReport::~ScopedInErrorReport (this=0x0, __in_chrg=<optimized out>) at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/asan/asan_report.cpp:190
#9  0xf7363688 in __asan::ReportGenericError (pc=<optimized out>, bp=bp@entry=4289649752, sp=sp@entry=4289649756, addr=3814153656, is_write=is_write@entry=false, access_size=access_size@entry=4, exp=exp@entry=0, fatal=fatal@entry=true) at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/asan/asan_report.cpp:478
#10 0xf7363e9a in __asan::__asan_report_load4 (addr=<optimized out>) at ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/asan/asan_rtl.cpp:120
#11 0xe3549104 in WPEFramework::ProxyStub::UnknownStubType<WPEFramework::RPC::IIteratorType<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, 5u>, &WPEFramework::ProxyStubs::RPCIteratorTypeInstance3383739DStubMethods>::UnknownStubType (this=0xe0b00490) at /usr/src/debug/lib32-wpeframework/4.4-r0/git/Source/core/../com/IUnknown.h:78
#12 WPEFramework::RPC::Administrator::Announce<WPEFramework::RPC::IIteratorType<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, 5u>, WPEFramework::ProxyStubs::RPCIteratorTypeInstance3383739DProxy, WPEFramework::ProxyStub::UnknownStubType<WPEFramework::RPC::IIteratorType<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, 5u>, &WPEFramework::ProxyStubs::RPCIteratorTypeInstance3383739DStubMethods> > (this=0xe3575480 <WPEFramework::RPC::Administrator::Instance()::systemAdministrator>) at /usr/src/debug/lib32-wpeframework/4.4-r0/git/Source/core/../com/IUnknown.h:74
#13 0xe350740e in WPEFramework::ProxyStubs::(anonymous namespace)::Instantiation::Instantiation (this=0xe3575ca0 <WPEFramework::ProxyStubs::(anonymous namespace)::ProxyStubRegistration>) at /usr/src/debug/lib32-wpeframework/4.4-r0/build/Source/com/generated/ProxyStubs_COM.cpp:848
#14 __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at /usr/src/debug/lib32-wpeframework/4.4-r0/build/Source/com/generated/ProxyStubs_COM.cpp:860
#15 _GLOBAL__sub_I_ProxyStubs_COM.cpp(void) () at /usr/src/debug/lib32-wpeframework/4.4-r0/build/Source/com/generated/ProxyStubs_COM.cpp:866
#16 0xf7820c10 in call_init (env=0xffaedf84, argv=0xffaedf74, argc=3, l=<optimized out>) at dl-init.c:70
#17 call_init (l=<optimized out>, argc=3, argv=0xffaedf74, env=0xffaedf84) at dl-init.c:26
#18 0xf7820cb6 in _dl_init (main_map=0xf784da38, argc=3, argv=0xffaedf74, env=0xffaedf84) at dl-init.c:117
#19 0xf782e768 in _dl_start_user () from ./lib/ld-linux-armhf.so.3
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```