### PR TITLE
OptionalType for index and iterators

### DIFF
--- a/JsonGenerator/source/class_emitter.py
+++ b/JsonGenerator/source/class_emitter.py
@@ -508,6 +508,21 @@ def EmitObjects(log, root, emit, if_file, additional_includes, emitCommon = Fals
             if obj.do_create and not obj.is_duplicate and not obj.included_from:
                 count += 1
 
+    def _EmitNoPushWarnings(prologue = True):
+        if prologue:
+            if not config.NO_PUSH_WARNING:
+                emit.Line("PUSH_WARNING(DISABLE_WARNING_TYPE_LIMITS)")
+                emit.Line()
+            else:
+                emit.Line("#if defined(__GNUC__) || defined(__clang__)")
+                emit.Line('#pragma GCC diagnostic ignored "-Wtype-limits"')
+                emit.Line("#endif")
+                emit.Line()
+        else:
+            if not config.NO_PUSH_WARNING:
+                emit.Line("POP_WARNING()")
+                emit.Line()
+
     emit.Line()
     emit.Line("// C++ classes for %s JSON-RPC API." % root.info["title"].replace("Plugin", "").strip())
     emit.Line("// Generated automatically from '%s'. DO NOT EDIT." % os.path.basename(if_file))
@@ -535,6 +550,7 @@ def EmitObjects(log, root, emit, if_file, additional_includes, emitCommon = Fals
     emit.Line("namespace %s {" % config.DATA_NAMESPACE)
     emit.Indent()
     emit.Line()
+    _EmitNoPushWarnings()
 
     if "info" in root.schema and "namespace" in root.schema["info"]:
         emit.Line("namespace %s {" % root.schema["info"]["namespace"])
@@ -584,6 +600,8 @@ def EmitObjects(log, root, emit, if_file, additional_includes, emitCommon = Fals
         emit.Unindent()
         emit.Line("} // namespace %s" % root.schema["info"]["namespace"])
         emit.Line()
+
+    _EmitNoPushWarnings(False)
 
     emit.Unindent()
     emit.Line("} // namespace %s" % config.DATA_NAMESPACE)

--- a/JsonGenerator/source/class_emitter.py
+++ b/JsonGenerator/source/class_emitter.py
@@ -62,7 +62,7 @@ class Restrictions:
         if (len(self.__cond) == 1):
             return self.__cond[0]
         elif (len(self.__cond) > 1):
-            return (" && ".join(self.__cond))
+            return ((" %s " % ("&&" if self.__reverse else "||")).join(self.__cond))
         else:
             return self.__comp[2]
 

--- a/JsonGenerator/source/header_loader.py
+++ b/JsonGenerator/source/header_loader.py
@@ -153,7 +153,10 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
 
             return type.Resolve()
 
-        def ConvertType(var, quiet=False):
+        def ConvertType(var, quiet=False, meta=None):
+            if not meta:
+                meta = var.meta
+
             if isinstance(var.type, str):
                 raise CppParseError(var, "%s: undefined type" % var.type)
             elif isinstance(var.type, list):
@@ -170,23 +173,23 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
             is_iterator = (isinstance(cppType, CppParser.Class) and cppType.is_iterator)
 
             # Pointers
-            if var_type.IsPointer() and (is_iterator or (var.meta.length and var.meta.length != ["void"])):
+            if var_type.IsPointer() and (is_iterator or (meta.length and meta.length != ["void"])):
                 # Special case for serializing C-style buffers, that will be converted to base64 encoded strings
                 if isinstance(cppType, CppParser.Integer) and cppType.size == "char":
                     props = dict()
 
-                    if var.meta.maxlength:
-                        props["length"] = " ".join(var.meta.maxlength)
-                    elif var.meta.length:
-                        props["length"] = " ".join(var.meta.length)
+                    if meta.maxlength:
+                        props["length"] = " ".join(meta.maxlength)
+                    elif meta.length:
+                        props["length"] = " ".join(meta.length)
 
                     if "length" in props:
                         props["@originaltype"] = cppType.type
 
                     props["encode"] = cppType.type != "char"
 
-                    if var.meta.range:
-                        props["range"] = var.meta.range
+                    if meta.range:
+                        props["range"] = meta.range
 
                     return "string", props if props else None
 
@@ -200,7 +203,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
 
                     result = ["array", { "items": ConvertParameter(currentMethod.retval), "iterator": StripInterfaceNamespace(cppType.type) } ]
 
-                    if "extract" in var.meta.decorators:
+                    if "extract" in meta.decorators:
                         result[1]["@extract"] = True
 
                     if var_type.IsPointerToPointer():
@@ -209,7 +212,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                     if var_type.IsPointerToConst():
                         raise CppParseError(var, "iterators must be passed as const pointers (not pointers to const)")
 
-                    if var.meta.range:
+                    if meta.range:
                         log.WarnLine(var, "'%s': @restrict has no effect on iterators" % var.name)
 
                     return result
@@ -224,7 +227,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
 
                 # String
                 if isinstance(cppType, CppParser.String):
-                    if "opaque" in var.meta.decorators :
+                    if "opaque" in meta.decorators :
                         result = [ "string", { "opaque": True } ]
                     else:
                         result = [ "string", {} ]
@@ -233,7 +236,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                 elif isinstance(cppType, CppParser.Bool):
                     result = ["boolean", {} ]
 
-                    if var.meta.range:
+                    if meta.range:
                         log.WarnLine(var, "'%s': @restrict has no effect on bools" % var.name)
 
                 # Integer
@@ -286,7 +289,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                             enum_spec["@endmarker"] = e.name
                             break;
 
-                    if "bitmask" in var.meta.decorators or "bitmask" in var.type.Type().meta.decorators:
+                    if "bitmask" in meta.decorators or "bitmask" in var.type.Type().meta.decorators:
                         enum_spec["type"] = "string"
                         enum_spec["@bitmask"] = True
                         enum_spec["@originaltype"] = StripFrameworkNamespace(var.type.Type().full_name)
@@ -297,7 +300,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                     if isinstance(var.type.Type(), CppParser.Typedef):
                         result[1]["@register"] = False
 
-                    if var.meta.range and not quiet:
+                    if meta.range and not quiet:
                         log.WarnLine(var, "'%s': @restrict has no effect on enums" % var.name)
 
                 # POD objects
@@ -350,45 +353,15 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                             raise CppParseError(var, "unable to convert this C++ class to JSON type: %s" % cppType.type)
 
                 elif isinstance(cppType, CppParser.Optional):
-                    result = ConvertType(cppType.optional)
+                    result = ConvertType(cppType.optional, meta=var.meta)
                     result[1]["@optionaltype"] = True
                     result[1]["@originaltype"] = StripFrameworkNamespace(cppType.optional)
 
-                    if var.meta.default:
-                        try:
-                            if result[1].get("float"):
-                                result[1]["@default"] = float(var.meta.default[0])
-                                result[1]["default"] = float(var.meta.default[0])
-                            elif result[0] == "integer":
-                                result[1]["@default"] = int(var.meta.default[0])
-                                result[1]["default"] = int(var.meta.default[0])
-                            elif result[0] == "boolean":
-                                result[1]["@default"] = "true" if var.meta.default[0] == "true" else "false"
-                                result[1]["default"] = (var.meta.default[0] == "true")
-                            elif result[1].get("enum"):
-                                if var.meta.default[0] not in result[1].get("ids"):
-                                    raise CppParseError(var, "default value for enumerator type is not an enum value")
-                                else:
-                                    result[1]["@default"] = result[1]["@originaltype"]+ "::" + str(var.meta.default[0])
-                                    result[1]["default"] = str(var.meta.default[0])
-                            else:
-                                if not var.meta.default[0].startswith('"') or not var.meta.default[0].endswith('"'):
-                                    raise CppParseError(var, "default value for string type must be a quoted string literal %s" % result[1].get("type"))
-
-                                result[1]["@default"] = '_T(' + str(var.meta.default[0]) + ')'
-                                result[1]["default"] = str(var.meta.default[0])
-
-                        except CppParseError as err:
-                            raise err
-                        except:
-                            raise CppParseError(var, "OptionalType and default value type mismatch (expected %s, got '%s')" % (result[1].get("@originaltype"), var.meta.default[0]))
+                    ConvertDefault(var, result[0], result[1])
 
                 # All other types are not supported
                 else:
                     raise CppParseError(var, "unable to convert this C++ type to JSON type: %s" % cppType.type)
-
-                if not isinstance(cppType, CppParser.Optional) and var.meta.default and not quiet:
-                    log.WarnLine(var, "'%s': @default on non OptionalType type has no effect" % var.name)
 
                 if result:
                     if var_type.IsPointer():
@@ -400,15 +373,15 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                     if var_type.IsPointerToConst():
                         result[1]["@ptrtoconst"] = True
 
-                    if var.meta.range:
-                        result[1]["range"] = var.meta.range
+                    if meta.range:
+                        result[1]["range"] = meta.range
 
-                        if var.meta.default:
+                        if meta.default:
                             if result[0] == "integer" or result[0] == "number":
-                                if float(var.meta.default[0]) < var.meta.range[0] or (float(var.meta.default[0]) > var.meta.range[1]):
+                                if float(meta.default[0]) < meta.range[0] or (float(meta.default[0]) > meta.range[1]):
                                     raise CppParseError(var, "default value is outside of restrict range")
                             elif result[0] == "string" and not result[1].get("enum"):
-                                if len(var.meta.default[0]) - 2 < var.meta.range[0] or (len(var.meta.default[0]) -2  > var.meta.range[1]):
+                                if len(meta.default[0]) - 2 < meta.range[0] or (len(meta.default[0]) -2  > meta.range[1]):
                                     raise CppParseError(var, "default value string length is outside of restrict range")
 
                 return result
@@ -468,6 +441,34 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                 events = ResolveTypedef(resolved, events, var.type)
             return events
 
+        def ConvertDefault(var, type, converted):
+            if var.meta.default:
+                try:
+                    if type == "integer":
+                        converted["@default"] = int(var.meta.default[0])
+                        converted["default"] = converted["@default"]
+                    elif type == "number":
+                        converted["@default"] = float(var.meta.default[0])
+                        converted["default"] = converted["@default"]
+                    elif type == "boolean":
+                        converted["@default"] = ("true" if var.meta.default[0] == "true" else "false")
+                        converted["default"] = (var.meta.default[0] == "true")
+                    if type == "string" and "enum" in converted:
+                        if var.meta.default[0] not in converted.get("ids"):
+                            raise CppParseError(var, "default value for enumerator type is not an enum value")
+                        converted["@default"] = converted["@originaltype"] + "::" + str(var.meta.default[0])
+                        converted["default"] = str(var.meta.default[0])
+                    elif type == "string":
+                        if not var.meta.default[0].startswith('"') or not var.meta.default[0].endswith('"'):
+                            raise CppParseError(var, "default value for string type must be a quoted string literal %s" % converted.get("type"))
+                        converted["@default"] = '_T(' + str(var.meta.default[0]) + ')'
+                        converted["default"] = str(var.meta.default[0][1:-1])
+                except CppParseError as err:
+                    raise err
+                except:
+                    raise CppParseError(var, "type and default value type mismatch (expected %s, got '%s')" % (converted.get("@originaltype"), var.meta.default[0]))
+
+
         def BuildParameters(obj, vars, rpc_format, is_property=False, test=False):
             params = {"type": "object"}
             properties = OrderedDict()
@@ -498,27 +499,30 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                         else:
                             raise CppParseError(var, "context parameter is only valid for methods")
                     else:
-                        properties[var_name] = converted
-
                         if not is_property and not var.name.startswith("@_") and not var.name.startswith("__unnamed"):
-                            properties[var_name]["@originalname"] = var.name
+                            converted["@originalname"] = var.name
 
-                        properties[var_name]["@position"] = vars.index(var)
+                        converted["@position"] = vars.index(var)
 
                         if "optional" not in var.meta.decorators:
                             required.append(var_name)
                         else:
-                            properties[var_name]["@optional"] = True
+                            converted["@optional"] = True
+                            converted["optional"] = True
+
+                            ConvertDefault(var, converted["type"], converted)
 
                             if not test:
                                 log.Info(var, "@optional tag is deprecated, use Core::OptionalType instead")
 
-                        if properties[var_name]["type"] == "string" and not var.type.IsReference() and not var.type.IsPointer() \
-                                and not "enum" in properties[var_name] and not "time" in properties[var_name]:
+                        if converted["type"] == "string" and not var.type.IsReference() and not var.type.IsPointer() \
+                                and not "enum" in converted and not "time" in converted:
                             log.WarnLine(var, "'%s': passing input string by value (forgot &?)" % var.name)
 
-                        if properties[var_name].get("@optionaltype") and not var.type.IsReference():
+                        if converted.get("@optionaltype") and not var.type.IsReference():
                             log.WarnLine(var, "'%s': passing input optional type by value (forgot &?)" % var.name)
+
+                        properties[var_name] = converted
 
 
             params["properties"] = properties
@@ -542,8 +546,7 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                     return params
 
         def BuildIndex(var, test=False):
-            index = BuildParameters(None, [var], rpc_format.COLLAPSED, True, test)
-            return index
+            return BuildParameters(None, [var], rpc_format.COLLAPSED, True, test)
 
         def BuildResult(vars, is_property=False):
             params = {"type": "object"}
@@ -689,53 +692,46 @@ def LoadInterfaceInternal(file, tree, ns, log, all = False, include_paths = []):
                 if len(method.vars) == 1 or (len(method.vars) == 2 and indexed_property):
                     if indexed_property:
                         if method.vars[0].type.IsPointer():
-                            raise CppParseError(method.vars[0], "index to a property must not be pointer")
+                            raise CppParseError(method.vars[0], "index to a property must not be a pointer")
 
                         if not method.vars[0].type.IsConst() and method.vars[0].type.IsReference():
-                            raise CppParseError(method.vars[0], "index to a property must be an input parameter")
+                            raise CppParseError(method.vars[0], "index to a property must be an const input parameter")
 
                         if "index" not in obj:
-                            obj["index"] = BuildIndex(method.vars[0])
+                            obj["index"] = [None, None]
 
-                            if obj["index"]:
-                                obj["index"]["name"] = (method.vars[0].name if _case_format == "keep" else method.vars[0].name.capitalize())
-                                obj["index"]["@originalname"] = method.vars[0].name
+                        _index_idx = (0 if "const" in method.qualifiers else 1)
 
-                                if "enum" in obj["index"]:
-                                    obj["index"]["example"] = obj["index"]["enum"][0]
+                        obj["index"][_index_idx] = BuildIndex(method.vars[0])
+                        _index = obj["index"][_index_idx]
 
-                                if "example" not in obj["index"]:
-                                    # example not specified, let's invent something...
-                                    obj["index"]["example"] = ("0" if obj["index"]["type"] == "integer" else "xyz")
+                        if _index:
+                            _index["name"] = (method.vars[0].name if _case_format == "keep" else method.vars[0].name.capitalize())
+                            _index["@originalname"] = method.vars[0].name
 
-                                if obj["index"]["type"] not in ["integer", "string", "boolean"]:
-                                    raise CppParseError(method.vars[0], "index to a property must be integer, enum or string type")
-                            else:
-                                raise CppParseError(method.vars[0], "failed to determine type of index")
+                            if "enum" in _index:
+                                _index["example"] = _index["enum"][0]
+
+                            if "example" not in obj["index"]:
+                                # example not specified, let's invent something...
+                                if method.vars[0].meta.default:
+                                    _index["example"] = method.vars[0].meta.default[0]
+                                else:
+                                    _index["example"] = ("0" if _index["type"] == "integer" else "xyz")
+
+                            if _index["type"] not in ["integer", "string", "boolean"]:
+                                raise CppParseError(method.vars[0], "index to a property must be integer, enum, boolean or string type")
                         else:
-                            test = BuildIndex(method.vars[0], True)
+                            raise CppParseError(method.vars[0], "failed to determine type of index")
 
-                            if "range" in test:
-                                if "range" in obj["index"] and obj["index"]["range"] != test["range"]:
-                                    log.WarnLine(method.vars[0], "'%s': inconsistent @restrict specifications between indexes of the same property" % method.vars[0].name)
-
-                                obj["index"]["range"] = test["range"]
-
-                            if "@default" in test:
-                                if "@default" in obj["index"] and obj["index"]["@default"] != test["@default"]:
-                                    log.WarnLine(method.vars[0], "'%s': inconsistent @default specifications between indexes of the same property" % method.vars[0].name)
-
-                                obj["index"]["@default"] = test["@default"]
-                                obj["index"]["default"] = test["default"]
-
-                            if not test:
-                                raise CppParseError(method.vars[value], "property index must be an input parameter")
-
-                            if obj["index"]["type"] != test["type"]:
+                        if obj["index"][0] and obj["index"][1]:
+                            if obj["index"][0]["type"] != obj["index"][1]["type"]:
                                 raise CppParseError(method.vars[0], "setter and getter of the same property must have same index type")
 
-                            if obj["index"].get("@optionaltype") != test.get("@optionaltype"):
-                                raise CppParseError(method.vars[0], "OptionalType is inconsistent between setter and getter of this property")
+                            if "description" in obj["index"][0] and "description" not in obj["index"][1]:
+                                obj["index"][1]["description"] = obj["index"][0]["description"]
+                            elif "description" in obj["index"][1] and "description" not in obj["index"][0]:
+                                obj["index"][0]["description"] = obj["index"][1]["description"]
 
                         if method.vars[1].meta.is_index:
                             raise CppParseError(method.vars[0], "index must be the first parameter to property method")

--- a/JsonGenerator/source/rpc_emitter.py
+++ b/JsonGenerator/source/rpc_emitter.py
@@ -73,7 +73,7 @@ def EmitEvent(emit, root, event, params_type, legacy = False):
                 parameters.append("const %s& %s" % (params.cpp_type, params.local_name))
 
         elif params_type == "object":
-            parameters.append("const %s& %s" % (params.cpp_type, params.local_name))
+           parameters.append("const %s& %s" % (params.cpp_type, params.local_name))
 
     if not legacy:
         parameters.insert(0, "const %s& %s" % (names.jsonrpc_alias, names.module))
@@ -321,14 +321,20 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
         if prologue:
             if not config.NO_PUSH_WARNING:
                 emit.Line("PUSH_WARNING(DISABLE_WARNING_UNUSED_FUNCTIONS)")
+                emit.Line("PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE)")
+                emit.Line("PUSH_WARNING(DISABLE_WARNING_TYPE_LIMITS)")
                 emit.Line()
             else:
                 emit.Line("#if defined(__GNUC__) || defined(__clang__)")
                 emit.Line('#pragma GCC diagnostic ignored "-Wunused-function"')
+                emit.Line('#pragma GCC diagnostic ignored "-Wdeprecated-declarations"')
+                emit.Line('#pragma GCC diagnostic ignored "-Wtype-limits"')
                 emit.Line("#endif")
                 emit.Line()
         else:
             if not config.NO_PUSH_WARNING:
+                emit.Line("POP_WARNING()")
+                emit.Line("POP_WARNING()")
                 emit.Line("POP_WARNING()")
                 emit.Line()
 
@@ -482,8 +488,120 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
     for m in methods_and_properties:
 
-        def _Invoke(params, response, parent="", repsonse_parent="", const_cast=False):
+        def _EmitIndexing(index):
+            nonlocal index_name
+
+            _index_checked = False
+            _index_name_converted = None
+            _index_name_optional = None
+
+            def _IsOptional(v):
+                return ((IsObjectOptional(v) and not IsObjectOptionalOrOpaque(v)))
+
+            def _IsLegacyOptional(v):
+                return (IsObjectOptionalOrOpaque(v))
+
+            def _EmitRestrictions(index_name, extra=None):
+                _index_restrictions = Restrictions(json=False)
+
+                if extra:
+                    _index_restrictions.extend(extra)
+
+                _index_restrictions.append(index, override=index_name)
+
+                if _index_restrictions.count():
+                    emit.Line("if (%s) {" % ( _index_restrictions.join()))
+                    emit.Indent()
+                    emit.Line("%s = %s;" % (error_code.temp_name, CoreError("bad_request")))
+                    emit.Unindent()
+                    emit.Line("}")
+
+                return _index_restrictions.count()
+
+            if _IsOptional(index) or _IsLegacyOptional(index):
+
+                if isinstance(index, JsonString):
+                    if not _IsLegacyOptional(index) or index.default_value:
+                        _index_name_optional = index.TempName("opt_")
+                        emit.Line("%s %s{};" %(index.cpp_native_type_opt, _index_name_optional))
+                else:
+                    _index_name_optional = index.TempName("opt_")
+                    emit.Line("%s %s{%s};" %(index.cpp_native_type_opt, _index_name_optional, index.default_value if index.default_value else ""))
+
+            if isinstance(index, JsonString):
+                if _IsOptional(index) or _IsLegacyOptional(index):
+                    if _IsOptional(index) or index.default_value:
+                        emit.Line("if (%s.empty() == false) {" % index_name)
+                        emit.Indent()
+
+                    cnt = _EmitRestrictions(index_name)
+                    if cnt:
+                        emit.Line("else {")
+                        emit.Indent()
+
+                    if _IsOptional(index) or index.default_value:
+                        emit.Line("%s = %s;" % (_index_name_optional, index_name))
+
+                    if cnt:
+                        emit.Unindent()
+                        emit.Line("}")
+
+                    if index.default_value:
+                        emit.Unindent()
+                        emit.Line("}")
+                        emit.Line("else {")
+                        emit.Indent()
+                        emit.Line("%s = %s;" %(_index_name_optional, index.default_value))
+
+                    if _IsOptional(index) or index.default_value:
+                        emit.Unindent()
+                        emit.Line("}")
+                else:
+                    _EmitRestrictions(index_name, extra=("(%s.empty() == true)" % index_name))
+                    _index_checked = True # still have to close the bracket...
+
+            elif isinstance(index, (JsonInteger, JsonBoolean, JsonEnum)):
+                if _IsOptional(index) or _IsLegacyOptional(index):
+                    emit.Line("if (%s.empty() == false) {" % index_name)
+                    emit.Indent()
+
+                _index_name_converted = index.TempName("conv_")
+
+                if isinstance(index, JsonEnum):
+                    emit.Line("Core::EnumerateType<%s> %s(%s.c_str());" % (index.cpp_native_type, _index_name_converted, index_name))
+                    _EmitRestrictions(_index_name_converted, extra="((%s.IsSet() == false)" % (_index_name_converted))
+                else:
+                    emit.Line("%s %s{};" % (index.cpp_native_type, _index_name_converted))
+                    _EmitRestrictions(_index_name_converted, extra="(Core::FromString(%s, %s) == false)" % (index_name, _index_name_converted))
+
+                if _IsOptional(index) or _IsLegacyOptional(index):
+                    emit.Line("else {")
+                    emit.Indent()
+                    emit.Line("%s = %s;" % (_index_name_optional, _index_name_converted))
+                    emit.Unindent()
+                    emit.Line("}")
+                    emit.Unindent()
+                    emit.Line("}")
+
+            emit.Line()
+
+            if _index_name_optional:
+                index_name = _index_name_optional
+            elif _index_name_converted:
+                index_name = _index_name_converted
+
+            _index_checked = ((_index_name_converted != None) or _index_checked)
+
+            if _index_checked:
+                emit.Line("if (%s == %s) {" % (error_code.temp_name, CoreError("none")))
+                emit.Indent()
+
+            return _index_checked
+
+        def _Invoke(params, response, parent="", repsonse_parent="", const_cast=False, index=None, test_param=True):
             vars = OrderedDict()
+
+            _index_checks_emitted = _EmitIndexing(index) if index else False
 
             # Build param/response dictionaries (dictionaries will ensure they do not repeat)
             if params:
@@ -530,7 +648,7 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
             buffer_restrictions_used = False
 
             if params:
-                restrictions.append(params, override=params.local_name)
+                restrictions.append(params, override=params.local_name, test_set=test_param)
 
                 if restrictions.present():
                     emit.Line()
@@ -621,37 +739,47 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
                 # Special case for iterators
                 elif isinstance(arg, JsonArray):
+                    face_name = "_" + arg.items.local_name.capitalize() + "IteratorType"
+
+                    if arg.optional and is_readable:
+                        emit.Line("Core::OptionalType<%s*> %s{};" % (face_name, arg.temp_name))
+                        emit.Line("if (%s.IsSet() == true) {" % (cpp_name))
+                        emit.Indent()
 
                     if arg.iterator:
-                        if arg.optional:
-                            raise RPCEmitterError("OptionalType iterators are not supported, use @optional tag (see %s)" % arg.cpp_native_type_opt)
-
-                        face_name = "_" + arg.items.local_name.capitalize() + "IteratorType"
                         emit.Line("using %s = %s;" % (face_name, arg.iterator))
 
                         if not is_writeable:
-                            arg.flags.release = True
+                            arg.flags.release = False if (arg.optional and is_readable) else True
 
                             elements_name = arg.items.TempName("elements")
                             iterator_name = arg.items.TempName("iterator")
                             impl_name = "_" + arg.items.local_name.capitalize() + "IteratorImplType"
 
-                            emit.Line("std::list<%s> %s;" % (arg.items.cpp_native_type, elements_name))
+                            emit.Line("std::list<%s> %s{};" % (arg.items.cpp_native_type, elements_name))
                             emit.Line("auto %s = %s.Elements();" % (iterator_name, cpp_name))
                             emit.Line("while (%s.Next() == true) { %s.push_back(%s.Current()); }" % (iterator_name, elements_name, iterator_name))
                             impl = (arg.iterator[:arg.iterator.index('<')].replace("IIterator", "Iterator") + ("<%s>" % face_name))
                             emit.Line("using %s = %s;" % (impl_name, impl))
                             initializer = "Core::ServiceType<%s>::Create<%s>(std::move(%s))" % (impl_name, face_name, elements_name)
-                            emit.Line("%s* const %s{%s};" % (face_name, arg.temp_name, initializer))
+                            if arg.optional and is_readable:
+                                emit.Line("%s = %s;" % (arg.temp_name, initializer))
+                            else:
+                                emit.Line("%s* const %s{%s};" % (face_name, arg.temp_name, initializer))
                             emit.Line("ASSERT(%s != nullptr); " % arg.temp_name)
 
                             if arg.schema.get("@byreference"):
                                 arg.flags.cast = "static_cast<%s* const&>(%s)" % (face_name, arg.temp_name)
 
+                            emit.Line()
+
                         elif not is_readable:
-                            emit.Line("%s%s* %s{};" % ("const " if arg.schema.get("@ptrtoconst") else "", face_name, arg.temp_name))
+                            if arg.optional:
+                                emit.Line("Core::OptionalType<%s*> %s{};" % (face_name, arg.temp_name))
+                            else:
+                                emit.Line("%s%s* %s{};" % ("const " if arg.schema.get("@ptrtoconst") else "", face_name, arg.temp_name))
                         else:
-                            raise RPCEmitterError("Read/write arrays (iterators) are not supported (see %s)" % arg.arg.cpp_native_type_opt)
+                            raise RPCEmitterError("Read/write arrays (iterators) are not supported (see %s)" % arg.cpp_native_type_opt)
 
                     elif arg.items.schema.get("@bitmask"):
                         initializer = cpp_name if is_readable else ""
@@ -668,6 +796,10 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
                     else:
                         raise RPCEmitterError("Arrays must be iterators: %s" % arg.json_name)
+
+                    if arg.optional and is_readable:
+                        emit.Unindent()
+                        emit.Line("}")
 
                 # All Other
                 else:
@@ -688,7 +820,8 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                         emit.Line("%s = %s;" % (arg.temp_name, cpp_name))
                         emit.Unindent()
                         if arg.default_value:
-                            emit.Line("} else {")
+                            emit.Line("}")
+                            emit.Line("else {")
                             emit.Indent()
                             emit.Line("%s = %s;" % (arg.temp_name, arg.default_value))
                             emit.Unindent()
@@ -719,20 +852,6 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                     emit.Line("if (%s != nullptr) {" % impl)
                     emit.Indent()
 
-                iterator_conditions = []
-
-                for _, [arg, _] in sorted_vars:
-                    if arg.flags.release:
-                        iterator_conditions.append("(%s != nullptr)" % arg.temp_name)
-
-                        if len(iterator_conditions) == 1:
-                            emit.Line()
-
-                if iterator_conditions:
-                    emit.Line()
-                    emit.Line("if (%s) {" % " && ".join(iterator_conditions))
-                    emit.Indent()
-
                 implementation_object = "(static_cast<const %s*>(%s))" % (interface, impl) if const_cast and not lookup else impl
                 function_params = []
 
@@ -747,18 +866,10 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
                 emit.Line("%s = %s->%s(%s);" % (error_code.temp_name, implementation_object, m.cpp_name, ", ".join(function_params)))
 
-                if iterator_conditions:
-                    for _, _record in sorted_vars:
-                        arg = _record[0]
-                        if arg.flags.release:
-                            emit.Line("%s->Release();" % arg.temp_name)
-
-                    emit.Unindent()
-                    emit.Line("} else {")
-                    emit.Indent()
-                    emit.Line("%s = %s;" % (error_code.temp_name, CoreError("general")))
-                    emit.Unindent()
-                    emit.Line("}")
+                for _, _record in sorted_vars:
+                    arg = _record[0]
+                    if arg.flags.release:
+                        emit.Line("%s->Release();" % arg.temp_name)
 
                 if lookup:
                     emit.Line("%s->Release();" % impl)
@@ -788,7 +899,7 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                 parameters = []
 
                 if indexed:
-                    parameters.append("const %s& %s" % (m.index.cpp_native_type, index_name))
+                    parameters.append("const %s& %s" % (any_index.cpp_native_type, index_name))
 
                 for _, [ arg, type ] in sorted_vars:
                     parameters.append("%s%s& %s" % ("const " if type == "r" else "", arg.cpp_type, arg.local_name))
@@ -810,6 +921,10 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                 for _, [arg, arg_type] in sorted_vars:
                     if "w" not in arg_type:
                         continue
+
+                    _rhs = arg.temp_name
+                    if arg.optional:
+                        _rhs += ".Value()"
 
                     cpp_name = (repsonse_parent + arg.cpp_name) if repsonse_parent else arg.local_name
 
@@ -837,30 +952,30 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                         if arg.iterator:
                             item_name = arg.items.TempName("item_")
 
-                            emit.Line("if (%s != nullptr) {" % arg.temp_name)
+                            emit.Line("if (%s != nullptr) {" % _rhs)
                             emit.Indent()
 
                             emit.Line("%s %s{};" % (arg.items.cpp_native_type, item_name))
-                            emit.Line("while (%s->Next(%s) == true) { %s.Add() = %s; }" % (arg.temp_name, item_name, cpp_name, item_name))
+                            emit.Line("while (%s->Next(%s) == true) { %s.Add() = %s; }" % (_rhs, item_name, cpp_name, item_name))
 
                             if arg.schema.get("@extract"):
                                 emit.Line("%s.SetExtractOnSingle(true);" % (cpp_name))
 
-                            emit.Line("%s->Release();" % arg.temp_name)
+                            emit.Line("%s->Release();" % _rhs)
                             emit.Unindent()
                             emit.Line("}")
 
                         elif arg.items.schema.get("@bitmask"):
-                            emit.Line("%s = %s;" % (cpp_name, arg.temp_name))
+                            emit.Line("%s = %s;" % (cpp_name, _rhs))
 
                         else:
                             raise RPCEmitterError("unable to serialize a non-iterator array: %s" % arg.json_name)
 
                     # All others...
                     else:
-                        emit.Line("%s = %s;" % (cpp_name, arg.temp_name + arg.convert_rhs))
+                        emit.Line("%s = %s;" % (cpp_name, _rhs + arg.convert_rhs))
 
-                        if arg.schema.get("opaque"):
+                        if arg.schema.get("opaque") and not repsonse_parent: # if comes from a struct it already has a SetQuoted
                             emit.Line("%s.SetQuoted(false);" % (cpp_name))
 
                 emit.Unindent()
@@ -870,14 +985,19 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                 emit.Unindent()
                 emit.Line("}")
 
+            if _index_checks_emitted:
+                emit.Unindent()
+                emit.Line("}")
+
         is_property = isinstance(m, JsonProperty)
+
+        contexted = (not is_property and m.context)
 
         # Prepare for handling indexed properties
         indexed = is_property and m.index
-        contexted = not is_property and m.context
-        index_name = m.index.local_name if indexed else None
-        index_name_converted = None
-        index_name_optional = None
+        any_index = (m.index[0] if m.index[0] else m.index[1]) if indexed else None
+        indexes_are_different = not m.index[2] if indexed else False
+        index_name = any_index.local_name if any_index else None
         lookup = m.schema.get("@lookup")
 
         if is_property:
@@ -953,109 +1073,14 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
         emit.Line("%s %s = %s;" % (error_code.cpp_native_type, error_code.temp_name, CoreError("none")))
         emit.Line()
 
+        _index_checks_emitted = _EmitIndexing(m.index[0]) if (indexed and not indexes_are_different) else False
+
         if not is_property:
             _Invoke((params if not params.is_void else None), (response if not response.is_void else None), params_parent, response_parent)
         else:
             is_read_only = m.readonly
             is_write_only = m.writeonly
             is_read_write = not m.readonly and not m.writeonly
-
-            if indexed:
-                def _EmitRestrictions(index_name, extra=None):
-                    _index_restrictions = Restrictions(json=False)
-
-                    if extra:
-                        _index_restrictions.extend(extra)
-
-                    _index_restrictions.append(m.index, override=index_name)
-
-                    if _index_restrictions.count():
-                        emit.Line("if (%s) {" % ( _index_restrictions.join()))
-                        emit.Indent()
-                        emit.Line("%s = %s;" % (error_code.temp_name, CoreError("bad_request")))
-                        emit.Unindent()
-                        emit.Line("}")
-
-                    return _index_restrictions.count()
-
-                if IsObjectOptional(m.index) and not IsObjectOptionalOrOpaque(m.index):
-                    index_name_optional = m.index.TempName("opt_")
-                    if isinstance(m.index, JsonString):
-                        emit.Line("%s %s{};" %(m.index.cpp_native_type_opt, index_name_optional))
-                    else:
-                        emit.Line("%s %s{%s};" %(m.index.cpp_native_type_opt, index_name_optional, m.index.default_value if m.index.default_value else ""))
-
-                if isinstance(m.index, JsonString):
-                    if IsObjectOptionalOrOpaque(m.index):
-                        _EmitRestrictions(index_name)
-
-                    elif not IsObjectOptional(m.index):
-                        _EmitRestrictions(index_name, extra=("(%s.empty() == true)" % index_name))
-                        index_name_converted = index_name
-
-                    else:
-                        emit.Line("if (%s.empty() == false) {" % index_name)
-                        emit.Indent()
-
-                        cnt = _EmitRestrictions(index_name)
-                        if cnt:
-                            emit.Line("else {")
-                            emit.Indent()
-
-                        emit.Line("%s = %s;" % (index_name_optional, index_name))
-
-                        if cnt:
-                            emit.Unindent()
-                            emit.Line("}")
-
-                        if m.index.default_value:
-                            emit.Unindent()
-                            emit.Line("}")
-                            emit.Line("else {")
-                            emit.Indent()
-                            emit.Line("%s = %s;" %(index_name_optional, m.index.default_value))
-                            emit.Unindent()
-                            emit.Line("}")
-
-                        emit.Unindent()
-                        emit.Line("}")
-
-
-                elif isinstance(m.index, (JsonInteger, JsonBoolean, JsonEnum)):
-                    if IsObjectOptional(m.index):
-                        emit.Line("if (%s.empty() == false) {" % index_name)
-                        emit.Indent()
-
-                    index_name_converted = m.index.TempName("conv_")
-
-                    if isinstance(m.index, JsonEnum):
-                        emit.Line("Core::EnumerateType<%s> %s(%s.c_str());" % (m.index.cpp_native_type, index_name_converted, index_name))
-                        _EmitRestrictions(index_name_converted, extra="((%s.IsSet() == false)" % (index_name_converted))
-                    else:
-                        emit.Line("%s %s{};" % (m.index.cpp_native_type, index_name_converted))
-                        _EmitRestrictions(index_name_converted, extra="(Core::FromString(%s, %s) == false)" % (index_name, index_name_converted))
-
-                    if IsObjectOptional(m.index):
-                        emit.Line("else {")
-                        emit.Indent()
-                        emit.Line("%s = %s;" % (index_name_optional, index_name_converted))
-                        emit.Unindent()
-                        emit.Line("}")
-                        emit.Unindent()
-                        emit.Line("}")
-
-                    index_name = index_name_converted
-
-                emit.Line()
-
-                if index_name_optional:
-                    index_name = index_name_optional
-                elif index_name_converted:
-                    index_name = index_name_converted
-
-            if index_name_converted:
-                emit.Line("if (%s == %s) {" % (error_code.temp_name, CoreError("none")))
-                emit.Indent()
 
             if is_read_write:
                 emit.Line("if (%s.IsSet() == false) {" % (params.local_name))
@@ -1067,7 +1092,10 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
             if not is_write_only:
                 assert not response.is_void
-                _Invoke(None, response, params_parent, response_parent, const_cast=is_read_write)
+                _Invoke(None, response, params_parent, response_parent, const_cast=is_read_write, index=m.index[0] if indexes_are_different else None, test_param=not is_read_write)
+
+                if indexes_are_different:
+                    index_name = any_index.local_name
 
             if not is_read_only:
                 if is_read_write:
@@ -1080,23 +1108,19 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                     emit.Line("// write-only property set")
 
                 assert not params.is_void
-                _Invoke(params, None, params_parent, response_parent)
+                _Invoke(params, None, params_parent, response_parent, index=m.index[1] if indexes_are_different else None, test_param=not is_read_write)
 
-                if is_read_write:
-                    emit.Unindent()
-                    emit.Line("}")
-
-            if index_name_converted:
-                emit.Unindent()
-                emit.Line("}")
+            if is_read_write:
+                emit.Line()
+                emit.Line("%s%s.Null(true);" % ("// FIXME " if isinstance(response, (JsonArray, JsonObject)) else "", response.local_name)) # FIXME
 
             if not is_read_only and is_read_write:
-                emit.Line()
-                emit.Line("if (%s.IsSet() == true) {" % (params.local_name))
-                emit.Indent()
-                emit.Line("%s%s.Null(true);" % ("// FIXME " if isinstance(response, (JsonArray, JsonObject)) else "", response.local_name)) # FIXME
                 emit.Unindent()
                 emit.Line("}")
+
+        if _index_checks_emitted:
+            emit.Unindent()
+            emit.Line("}")
 
         emit.Line()
 

--- a/ProxyStubGenerator/default.h
+++ b/ProxyStubGenerator/default.h
@@ -47,6 +47,10 @@ namespace std {
 
 namespace __FRAMEWORK_NAMESPACE__ {
 
+  namespace ProxyStub {
+    class UnknownProxy;
+  }
+
   namespace Core {
     typedef __stubgen_instance_id instance_id;
     typedef __stubgen_time Time;


### PR DESCRIPTION
- OptionalType<T> now works with indexes,
- OptionalType<T> now works where T is Iterator*,
- OptionalType<T> now works where T is bitmask,
- OptionalType<T> now works with stub security,
- `@restrict` now works with indexes,
- `@default` is now checked against `@restrict` range (compile time),
- indexes to setter/getter can now differ by OptionalType, `@optional`, `@restrict` and `@default`,
- bool can now also be used as index type.

`@optional` is still supported and also handles `@default` but is made redundant by OptionalType