### PR TITLE
Updating python dependencies to make DocumentGenerator script work again

### DIFF
--- a/DocumentGenerator/requirements.txt
+++ b/DocumentGenerator/requirements.txt
@@ -2,10 +2,10 @@ click==8.0.3
 ghp-import==2.0.2
 gitdb==4.0.9
 GitPython==3.1.30
-importlib-metadata==4.8.1
+importlib-metadata==8.5.0
 Jinja2==3.0.2
 jsonref==0.2
-Markdown==3.3.4
+Markdown==3.7
 MarkupSafe==2.0.1
 mergedeep==1.3.4
 mkdocs==1.2.3
@@ -16,10 +16,10 @@ Pygments==2.10.0
 pymdown-extensions==9.0
 pyparsing==2.4.7
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.2
 pyyaml-env-tag==0.1
 six==1.16.0
 smmap==5.0.0
 typing-extensions==3.10.0.2
 watchdog==2.1.6
-zipp==3.6.0
+zipp==3.20


### PR DESCRIPTION
**To fix the below issue:**
`AttributeError: cython_sources`

_PyYAML version changed from 6.0 to 6.0.2_

**To fix below issue:**
`AttributeError: 'EntryPoints' object has no attribute 'get'`

_importlib-metadata version changed from 4.8.1 to 8.5.0_
_Markdown version changed from 3.3.4 to 3.7_

**To have Markdown 3.7 to be installed:**
_zipp version changed from 3.6.0 to 3.20_