### PR TITLE
[JsonGen] Buffer encoding enhancements

### DIFF
--- a/JsonGenerator/source/class_emitter.py
+++ b/JsonGenerator/source/class_emitter.py
@@ -103,7 +103,7 @@ class Restrictions:
         else:
             assert False, "invalid type"
 
-    def append(self, argument, relay=None, override=None, test_set=None):
+    def append(self, argument, relay=None, override=None, test_set=None, json=True):
         if test_set == None:
             test_set = self.__test_set
 
@@ -112,7 +112,7 @@ class Restrictions:
 
         name = relay.temp_name if not override else override
 
-        if isinstance(relay, JsonObject) and self.__json:
+        if isinstance(relay, JsonObject) and self.__json and json:
             if test_set:
                 if IsObjectOptional(relay):
                     if self.__reverse:
@@ -138,9 +138,9 @@ class Restrictions:
             if range:
                 if isinstance(relay, JsonString):
                     if range[0] != 0:
-                        tests.append("%s%s.size() %s %s" % (name, (".Value()" if self.__json else ""), self.__comp[0], range[0]))
+                        tests.append("%s%s.size() %s %s" % (name, (".Value()" if self.__json and json else ""), self.__comp[0], range[0]))
 
-                    tests.append("%s%s.size() %s %s" % (name, (".Value()" if self.__json else ""), self.__comp[1], range[1]))
+                    tests.append("%s%s.size() %s %s" % (name, (".Value()" if self.__json and json else ""), self.__comp[1], range[1]))
 
                 elif isinstance(relay, JsonArray):
                     if range[0]:
@@ -155,7 +155,7 @@ class Restrictions:
                     tests.append("%s %s %s" % (name, self.__comp[1], range[1]))
 
             if tests:
-                if test_set and self.__json:
+                if test_set and self.__json and json:
                     if IsObjectOptional(argument):
                         if self.__reverse:
                             self.__cond.append("(%s.IsSet() == false) || (%s)" % (name, " &&".join(tests)))
@@ -169,7 +169,7 @@ class Restrictions:
                 else:
                     self.__cond.extend(tests)
 
-        elif test_set and self.__json and not IsObjectOptional(relay):
+        elif test_set and self.__json and json and not IsObjectOptional(relay):
             self.__cond.append("%s.IsSet() == %s" % (name, self.__comp[2]))
 
 def ProcessEnums(log, action=None):

--- a/JsonGenerator/source/emitter.py
+++ b/JsonGenerator/source/emitter.py
@@ -110,3 +110,24 @@ class Emitter():
                 return
         self.Unindent()
         self.Line("}")
+
+    def If(self, conditions):
+        if conditions:
+            self.EnterBlock(conditions)
+            return conditions.present()
+        return False
+
+    def Endif(self, conditions):
+        if conditions:
+            self.ExitBlock(conditions)
+
+    def Else(self, conditions):
+        self.Endif(conditions)
+        if conditions:
+            self.Line("else {")
+            self.Indent()
+            return conditions.present()
+        return False
+
+
+

--- a/JsonGenerator/source/json_loader.py
+++ b/JsonGenerator/source/json_loader.py
@@ -258,6 +258,13 @@ class JsonType():
             return self.cpp_native_type
 
     @property
+    def original_type_opt(self):
+        if self.optional:
+            return ("Core::OptionalType<%s>" % self.original_type)
+        else:
+            return self.cpp_original_type
+
+    @property
     def cpp_native_type_opt_cv(self):
         if self.optional:
             cv = ""
@@ -915,7 +922,7 @@ class JsonCallback(JsonMethod):
     def __init__(self, name, parent, notification, schema, included=None):
         JsonMethod.__init__(self, name, parent, schema, included)
         self.notification = notification
-        self.notification.sendif_type = JsonItem("id", self, { "type": "string"})
+        self.notification.sendif_type = JsonItem("id", self, { "type": "string", "@originalname": "designatorId"})
 
 class JsonProperty(JsonMethod):
     def __init__(self, name, parent, schema, included=None):


### PR DESCRIPTION
- support @encode:base64 for std::vector
- support @encode:mac and @encode:hex for uint8_t* buffer, array[] and std::vector
- array[] and std::vector can be now property index (if @encode is used)
- array[] and std::vector can now be id in notification (if @encode is used)
- Core::OptionalType can now be id in notification