### PR TITLE
[JsonGen] Serialize empty non-optional arrays and objects

### DIFF
--- a/JsonGenerator/source/class_emitter.py
+++ b/JsonGenerator/source/class_emitter.py
@@ -329,8 +329,14 @@ def EmitObjects(log, root, emit, if_file, additional_includes, emitCommon = Fals
                             emit.Unindent()
                             emit.Line("}")
                         elif prop.schema.get("@container"):
+                            if not optional_type and type == "conv":
+                                emit.Line("%s.Set(true);" % prop.cpp_name)
+
                             emit.Line("for (auto const& _element : %s.%s%s) { %s.Add() = _element; }" % (other, _prop_name, ".Value()" if prop.optional else "", prop.cpp_name))
                     else:
+                        if isinstance(prop, (JsonArray, JsonObject)) and not optional_type and type == "conv":
+                            emit.Line("%s.Set(true);" % prop.cpp_name)
+
                         emit.Line("%s = %s.%s;" % (prop.cpp_name, other, _prop_name  + (((".Value()" if prop.optional else "") + prop.convert_rhs) if (type == "conv") else "")))
 
                     if (prop.optional and not prop.default_value) or _optional_or_opaque:

--- a/JsonGenerator/source/rpc_emitter.py
+++ b/JsonGenerator/source/rpc_emitter.py
@@ -305,11 +305,11 @@ def EmitEvent(emit, ns, root, event, params_type, legacy=False, has_client=False
 
                             if not length_param:
                                 raise RPCEmitterError("@length parameter not found: %s" % length_value)
-                            else:
-                                if length_param.optional:
-                                    emit.Line("if (%s.IsSet() == true) {" % length_value)
-                                    emit.Indent()
-                                    length_value += ".Value()"
+
+                            if length_param.optional:
+                                emit.Line("if (%s.IsSet() == true) {" % length_value)
+                                emit.Indent()
+                                length_value += ".Value()"
 
                             if legacy_array:
                                 emit.Line("%s = %s;" % (cpp_name, local_name))
@@ -1480,6 +1480,9 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
                         emit.Line("}")
 
                 elif isinstance(param, JsonArray):
+                    if not param.optional:
+                        emit.Line("%s.Set(true);" % cpp_name)
+
                     if param.iterator:
                         conditions = Restrictions(reverse=True)
                         conditions.check_set(param)
@@ -1538,6 +1541,10 @@ def _EmitRpcCode(root, emit, ns, header_file, source_file, data_emitted):
 
                 # All others...
                 else:
+                    if isinstance(param, JsonObject):
+                        if not param.optional:
+                            emit.Line("%s.Set(true);" % cpp_name)
+
                     if param_meta.flags.store_lookup:
                        emit.Line("%s = %s.PluginHost::JSONRPCSupportsAutoObjectLookup::template Store<%s>(_real%s, %s);" % (param.temp_name, names.module, trim(param.original_type), param.temp_name, names.context))
                        emit.Line("_real%s->Release();" % param.temp_name)


### PR DESCRIPTION
If an element is not optional it is always emitted, including arrays as [] and objects as {}.
Unset optional elements are omitted, unless the element is the result of JSON-RPC "result" field, then it is emitted as null.