### PR TITLE
Allow setting only lower bound of @restrict range

### DIFF
--- a/JsonGenerator/source/class_emitter.py
+++ b/JsonGenerator/source/class_emitter.py
@@ -138,7 +138,13 @@ class Restrictions:
             range = relay.schema.get("range")
 
             if range:
-                if isinstance(relay, (JsonString, JsonMacAddress)):
+                if isinstance(relay, (JsonInteger, JsonNumber)):
+                    if range[0]:
+                        tests.append("%s.Value() %s %s" % (name, self.__comp[0], range[0]))
+                    if range[1]:
+                        tests.append("%s.Value() %s %s" % (name, self.__comp[1], range[1]))
+
+                elif isinstance(relay, (JsonString, JsonMacAddress)):
                     if ("@arraysize" not in relay.schema and not isinstance(relay, JsonMacAddress)) or self.__json:
                         if isinstance(relay, JsonMacAddress):
                             encode = "mac"
@@ -162,35 +168,39 @@ class Restrictions:
 
                         size_method = "size"
 
-                        if adjusted[0] != 0:
+                        if adjusted[0]:
                             tests.append("%s%s.%s() %s %s" % (name, (".Value()" if self.__json and json else ""), size_method, self.__comp[0], adjusted[0]))
 
-                        tests.append("%s%s.%s() %s %s" % (name, (".Value()" if self.__json and json else ""), size_method, self.__comp[1], adjusted[1]))
+                        if adjusted[1]:
+                            tests.append("%s%s.%s() %s %s" % (name, (".Value()" if self.__json and json else ""), size_method, self.__comp[1], adjusted[1]))
 
                 elif isinstance(relay, JsonArray):
                     if self.__json:
                         if range[0]:
                             tests.append("%s.Length() %s %s" % (name, self.__comp[0], range[0]))
 
-                        tests.append("%s.Length() %s %s" % (name, self.__comp[1], range[1]))
+                        if range[1]:
+                            tests.append("%s.Length() %s %s" % (name, self.__comp[1], range[1]))
                     else:
                         if "@container" in relay.schema:
                             if range[0]:
                                 tests.append("%s.size() %s %s" % (name, self.__comp[0], range[0]))
 
-                            tests.append("%s.size() %s %s" % (name, self.__comp[1], range[1]))
+                            if range[1]:
+                                tests.append("%s.size() %s %s" % (name, self.__comp[1], range[1]))
 
                         elif "@iterator" in relay.schema:
                             if range[0]:
                                 tests.append("%s.Count() %s %s" % (name, self.__comp[0], range[0]))
 
-                            tests.append("%s.Count() %s %s" % (name, self.__comp[1], range[1]))
+                            if range[1]:
+                                tests.append("%s.Count() %s %s" % (name, self.__comp[1], range[1]))
 
             if tests:
                 if test_set and self.__json and json:
                     if IsObjectOptional(argument):
                         if self.__reverse:
-                            self.__cond.append("(%s.IsSet() == false) || (%s)" % (name, " &&".join(tests)))
+                            self.__cond.append("(%s.IsSet() == false) || (%s)" % (name, " && ".join(tests)))
                         else:
                             self.__cond.append("(%s.IsSet() == true) && (%s)" % (name, " || ".join(tests)))
                     else:

--- a/ProxyStubGenerator/StubGenerator.py
+++ b/ProxyStubGenerator/StubGenerator.py
@@ -541,6 +541,10 @@ def GenerateLuaData(emit, interfaces_list, enums_list, source_file=None, tree=No
         emit.Line("}")
         emit.Line()
 
+def RangeStr(range):
+    assert len(range) == 2
+    return "%s..%s" % (range[0] if range[0] else "min", range[1] if range[1] else "max")
+
 def Parse(source_file, framework_namespace, includePaths = [], defaults = "", extra_includes = []):
 
     log.Info("Parsing %s..." % source_file)
@@ -881,7 +885,7 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                         raise TypenameError(self.identifier, "'%s': this type cannot be a buffer length carrying parameter" % self.trace_proto)
                     if self.kind.size == "long long":
                         raise TypenameError(self.identifier, "'%s': 64-bit buffer length carrying parameter is not supported" % self.trace_proto)
-                    elif self.kind.size == "long" and not self.identifier.meta.range:
+                    elif self.kind.size == "long" and not self.identifier.meta.range.is_set:
                         log.WarnLine(self.identifier, "'%s': long int buffer length is supported, but buffers up to %s bytes are recommended" \
                                         % (self.trace_proto, PARAMETER_SIZE_WARNING_THRESHOLD))
                     if not self.kind.fixed:
@@ -896,7 +900,7 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                         raise TypenameError(self.identifier, "'%s': this type cannot be a buffer max-length carrying parameter" % self.trace_proto)
                     if self.kind.size == "long long":
                         raise TypenameError(self.identifier, "'%s': 64-bit buffer max-length carrying parameter is not supported" % self.trace_proto)
-                    elif self.kind.size == "long" and not self.identifier.meta.range:
+                    elif self.kind.size == "long" and not self.identifier.meta.range.is_set:
                         log.WarnLine(self.identifier, "'%s': long int buffer max-length is supported, but buffers up to %s bytes are recommended" \
                                             % (self.trace_proto, PARAMETER_SIZE_WARNING_THRESHOLD))
                     if not self.kind.fixed:
@@ -931,7 +935,7 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                 # Lastly handle restrict
                 self.restrict_range = identifier.meta.range
 
-                if not self.restrict_range:
+                if not self.restrict_range.is_set:
                     if self.length and self.length.identifier.meta.range:
                         self.restrict_range = self.length.identifier.meta.range
                     elif self.max_length and self.max_length.identifier.meta.range:
@@ -941,56 +945,46 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                     elif self.max_length_of and self.max_length_of.meta.range:
                         self.restrict_range = self.max_length_of.meta.range
 
-                if self.restrict_range:
+                if self.restrict_range.is_set:
                     if self.is_integer and not self.is_buffer:
-                        if (self.restrict_range[1] > self.kind.max) or (self.restrict_range[0] < self.kind.min):
-                            raise TypenameError(self.identifier, "'%s': restrict range (%s..%s) is invalid for this length integer limits (%s..%s)" % \
-                                                    (self.trace_proto, self.restrict_range[0], self.restrict_range[1], self.kind.min, self.kind.max))
-
-                        if not no_length_warnings and (((self.restrict_range[1] < 256) and (self.kind.max > 256)) \
-                                or ((self.restrict_range[1] < (64*1024)) and (self.kind.max > (64*1024))) \
-                                or ((self.restrict_range[1] < (4*1024*1024*1024)) and (self.kind.max > (4*1024*1024*1024)))):
-                            log.WarnLine(identifier, "'%s': inefficient use of type (%s), value restricted to range (%s..%s)" % \
-                                            (self.trace_proto, self.proto_no_cv, self.restrict_range[0], self.restrict_range[1]))
+                        if not no_length_warnings and self.restrict_range.has_max:
+                            if (((self.restrict_range.max < 256) and (self.kind.max > 256)) \
+                                    or ((self.restrict_range.max < (64*1024)) and (self.kind.max > (64*1024))) \
+                                    or ((self.restrict_range.max < (4*1024*1024*1024)) and (self.kind.max > (4*1024*1024*1024)))):
+                                log.WarnLine(identifier, "'%s': inefficient use of type (%s) as value restricted to range (%s)" % (self.trace_proto, self.proto_no_cv, self.restrict_range))
 
                     elif (self.is_buffer or self.is_string or (self.is_integer and self.kind.min == 0)):
-                        if self.restrict_range[0] < 0:
-                            raise TypenameError(self.identifier, "'%s': negative restrict range (%s..%s) is invalid for this type" % \
-                                                    (self.trace_proto, self.restrict_range[0], self.restrict_range[1]))
-
-                        elif self.restrict_range[1] > (PARAMETER_SIZE_WARNING_THRESHOLD):
-                            log.WarnLine(identifier, "'%s': parameters up to %s bytes are recommended for COM-RPC, see range (%s..%s)" \
-                                            % (self.trace_proto, PARAMETER_SIZE_WARNING_THRESHOLD, self.restrict_range[0], self.restrict_range[1]))
+                        if self.restrict_range.has_max and self.restrict_range.max > (PARAMETER_SIZE_WARNING_THRESHOLD):
+                            log.WarnLine(identifier, "'%s': parameters up to %s bytes are recommended for COM-RPC, see range (%s)" \
+                                            % (self.trace_proto, PARAMETER_SIZE_WARNING_THRESHOLD, self.restrict_range))
 
                 if isinstance(self.kind, CppParser.DynamicArray):
                     aux_size = "uint16_t"
-                    if self.restrict_range:
-                        if self.restrict_range[1] < 256:
+                    if self.restrict_range.has_max:
+                        if self.restrict_range.max < 256:
                             aux_size = "uint8_t"
-                        elif self.restrict_range[1] > 65535:
+                        elif self.restrict_range.max > 65535:
                             raise TypenameError(identifier, "invalid restrict range for std::vector")
 
                     self.length = CppParser.Temporary(self.kind.element.parent, [aux_size])
                     self.length.type_name = aux_size
                     self.element = self.kind.element
                     self.is_dynamic_array = True
-                    if not self.restrict_range:
-                        raise TypenameError(identifier, "'%s': @restrict is required for std::vector" % self.trace_proto)
 
                 if self.is_string or self.is_buffer or self.is_array or self.is_dynamic_array:
                     aux_name = Normalize(self.name + "PeekedLen__")
                     aux_size = "uint16_t"
 
-                    if self.restrict_range:
-                        if self.restrict_range[1] >= (16*1024*1024):
+                    if self.restrict_range.has_max:
+                        if self.restrict_range.max >= (16*1024*1024):
                             aux_size = "uint32_t"
-                        elif self.restrict_range[1] >= (64*1024):
+                        elif self.restrict_range.max >= (64*1024):
                             aux_size = "Core::Frame::UInt24"
-                        elif self.restrict_range[1] < 256:
+                        elif self.restrict_range.max < 256:
                             aux_size = "uint8_t"
 
                     if self.is_string:
-                        if self.is_ccstring and not self.restrict_range:
+                        if self.is_ccstring and not self.restrict_range.is_set:
                             log.WarnLine(identifier, "'%s': parameters up to %s bytes are recommended for COM-RPC" \
                                             % (self.trace_proto, PARAMETER_SIZE_WARNING_THRESHOLD))
                             aux_size = "uint32_t"
@@ -998,19 +992,21 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                         self.peek_length = AuxIdentifier(CppParser.Integer(aux_size), (CppParser.Ref.VALUE | CppParser.Ref.CONST), aux_name)
 
                     elif self.is_buffer or self.is_array or self.is_dynamic_array:
-                        if not self.restrict_range:
+                        if not self.restrict_range.is_set:
                             aux_size = (self.length.type_name if self.length else self.max_length.type_name)
 
                         self.peek_length = AuxIdentifier(CppParser.Integer(aux_size), (CppParser.Ref.VALUE | CppParser.Ref.CONST), aux_name)
 
                 elif self.is_integer:
-                    if self.restrict_range and self.kind.size == "long":
+                    # Opportunity to shrink DWORD to 24-bit if restrict range fits
+                    if self.kind.size == "long":
                         if self.kind.signed:
-                            if (((self.restrict_range[0] < (-32*1024)) and (self.restrict_range[0] >= (-8*1024*1024))) or \
-                                  ((self.restrict_range[1] >= (32*1024)) and (self.restrict_range[1] < (8*1024*1024)))):
-                                self.type_name = "Core::Frame::SInt24"
+                            if self.restrict_range.has_min and self.restrict_range.has_max:
+                                if ((self.restrict_range.min < (-32*1024)) and (self.restrict_range.min >= (-8*1024*1024))) or \
+                                    ((self.restrict_range.max >= (32*1024)) and (self.restrict_range.max < (8*1024*1024))):
+                                    self.type_name = "Core::Frame::SInt24"
                         else:
-                            if ((self.restrict_range[1] >= (64*1024)) and (self.restrict_range[1] < (16*1024*1024))):
+                            if (self.restrict_range.has_max and ((self.restrict_range.max >= (64*1024)) and (self.restrict_range.max < (16*1024*1024)))):
                                 self.type_name = "Core::Frame::UInt24"
 
                 if isinstance(self.kind, CppParser.Optional):
@@ -1038,9 +1034,6 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                         self.item = self.optional.item
                     if not self.element:
                         self.element = self.optional.element
-
-                    #if not self.is_array:
-                    #    self.suffix = ".Value()"
 
                     if self.is_compound:
                         if isinstance(self.optional.kind, CppParser.Optional):
@@ -1335,14 +1328,20 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
                             (vars["reader"], (p.as_rvalue if by_parameter else p.storage_size)))
 
         def CheckRange(p, val):
-            if p.restrict_range:
+            if p.restrict_range.is_set:
                 cmp = val if isinstance(val, str) else val.as_pure_rvalue
 
-                emit.Line("ASSERT((%s >= %s) && (%s <= %s));"% (cmp, p.restrict_range[0], cmp, p.restrict_range[1]))
+                restrictions = []
+
+                if p.restrict_range.has_min:
+                    restrictions.append("(%s >= %s)" % (cmp, p.restrict_range.min))
+                if p.restrict_range.has_max:
+                    restrictions.append("(%s <= %s)" % (cmp, p.restrict_range.max))
+
+                emit.Line("ASSERT(%s);" % " && ".join(restrictions))
 
                 if ENABLE_RANGE_VERIFICATION:
-                    emit.Line("if (!((%s >= %s) && (%s <= %s))) { return (COM_ERROR | Core::ERROR_INVALID_RANGE); }" % \
-                                (cmp, p.restrict_range[0], cmp, p.restrict_range[1]))
+                    emit.Line("if (!(%s)) { return (COM_ERROR | Core::ERROR_INVALID_RANGE); }" % " && ".join(restrictions))
 
         def CheckSize(p):
             if ENABLE_INTEGRITY_VERIFICATION:
@@ -1390,7 +1389,7 @@ def GenerateStubs2(output_file, source_file, tree, ns, scan_only=False):
 
             hresult = AuxIdentifier(CppParser.Integer(HRESULT), CppParser.Ref.VALUE, vars["hresult"])
 
-            has_restricted_parameters = any([v.restrict_range for v in input_params])
+            has_restricted_parameters = any([v.restrict_range.is_set for v in input_params])
 
             output_buffers = []
             custom_buffers = []
@@ -2587,7 +2586,7 @@ if __name__ == "__main__":
         print("   @out                   - indicates an output parameter")
         print("   @inout                 - indicates an input/output parameter (equivalent of @in @out)")
         print("   @restrict              - specifies valid range for a parameter (for buffers and strings: valid size)")
-        print("                            e.g.: @restrict:1..32, @restrict:256..1K, @restrict:1M-1")
+        print("                            e.g.: @restrict:1..32, @restrict:256..1K, @restrict:1M-1, @restrict:1..")
         print("   @interface:{expr}      - specifies a parameter or value indicating interface ID value for void* interface passing")
         print("   @length:{expr}         - specifies a buffer length value (a constant, a parameter name or a math expression)")
         print("   @maxlength:{expr}      - specifies a maximum buffer length value (a constant, a parameter name or a math expression),")


### PR DESCRIPTION
with syntax @restrict:5..

also adds some sanity checks on restrict input and fixes bug where restricted integer and float parameters were not verified in json-rpc