### PR TITLE
[StubGenerator] Fix signed int24_t emitting non-existent Core::Int24 type

### DIFF
--- a/JsonGenerator/source/json_loader.py
+++ b/JsonGenerator/source/json_loader.py
@@ -358,7 +358,7 @@ class JsonInteger(JsonNative, JsonFundamental, JsonType):
         self.__cpp_class = CoreJson("Dec%sInt%i" % ("S" if self.signed else "U", self.size if self.size != 24 else 32))
 
         if self.size == 24:
-            self.__cpp_native_type = "Core::Int24" if self.signed else "Core::UInt24"
+            self.__cpp_native_type = "Core::SInt24" if self.signed else "Core::UInt24"
         else:
             self.__cpp_native_type = "%sint%i_t" % ("" if self.signed else "u", self.size)
 

--- a/ProxyStubGenerator/CppParser.py
+++ b/ProxyStubGenerator/CppParser.py
@@ -232,7 +232,7 @@ class Bool(Fundamental):
 
 class Int24(Fundamental):
     def __init__(self, signed=False):
-        Fundamental.__init__(self, "Core::Int24" if signed else "Core::UInt24")
+        Fundamental.__init__(self, "Core::SInt24" if signed else "Core::UInt24")
         self.signed = signed
         self.fixed = False
         self.min = -2**23 if signed else 0


### PR DESCRIPTION
CppParser.Int24 was initialised with "Core::Int24" for the signed case, but the correct Thunder type is "Core::SInt24". This caused the generated ProxyStubs to fail compilation with "Int24 is not a member of Thunder::Core".